### PR TITLE
refactor: 리스트 조회 쿼리문 개선

### DIFF
--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/entity/ProductCategory.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/entity/ProductCategory.kt
@@ -2,15 +2,15 @@ package com.NBE_4_5_2.Team5.domain.post.post.entity
 
 import com.NBE_4_5_2.Team5.domain.base.entity.BaseLongIdEntity
 import com.NBE_4_5_2.Team5.domain.post.category.entity.Category
-import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.*
 import lombok.AccessLevel
 import lombok.AllArgsConstructor
 import lombok.NoArgsConstructor
 
 @Entity
+@Table(name = "ProductCategory", indexes = [
+    Index(name = "idx_productcategory", columnList = "product_post_id, category_id")
+])
 class ProductCategory(
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/repository/ProductPostRepository.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/repository/ProductPostRepository.kt
@@ -52,6 +52,13 @@ interface ProductPostRepository : JpaRepository<ProductPost, String> {
         """
     SELECT DISTINCT p FROM ProductPost p
     WHERE p.productPrice >= :minPrice AND p.productPrice <= :maxPrice
+""", countQuery = """
+    SELECT count( p) 
+    FROM
+        ProductPost p 
+    WHERE
+        p.productPrice >= :minPrice 
+        AND p.productPrice <= :maxPrice
 """
     )
     fun findAllWithPrice(
@@ -60,12 +67,38 @@ interface ProductPostRepository : JpaRepository<ProductPost, String> {
         pageable: Pageable
     ): Page<ProductPost>
 
-    @Query("""
-    SELECT p FROM ProductPost p
-    JOIN p.productCategories pc
-    WHERE p.productPrice >= :minPrice AND p.productPrice <= :maxPrice
-    GROUP BY p
-    HAVING COUNT(DISTINCT CASE WHEN pc.category.id IN :categoryIds THEN pc.category.id END) = :categoryCount
+//    """
+//    SELECT p FROM ProductPost p
+//    JOIN p.productCategories pc
+//    WHERE p.productPrice >= :minPrice AND p.productPrice <= :maxPrice
+//    GROUP BY p
+//    HAVING COUNT(DISTINCT CASE WHEN pc.category.id IN :categoryIds THEN pc.category.id END) = :categoryCount
+//"""
+
+    @Query(
+        """
+            SELECT p 
+FROM ProductPost p 
+WHERE  p.productPrice BETWEEN :minPrice AND :maxPrice 
+ AND p.id IN (
+    SELECT pp.id 
+    FROM ProductPost pp 
+    JOIN pp.productCategories pc 
+    WHERE pp.productPrice BETWEEN :minPrice AND :maxPrice 
+    AND pc.category.id IN :categoryIds
+    GROUP BY pp.id
+    HAVING COUNT(DISTINCT pc.category.id) = :categoryCount
+)
+ORDER BY p.createdDate DESC
+        """
+        ,
+        countQuery = """
+    SELECT count( p) 
+    FROM
+        ProductPost p 
+    WHERE
+        p.productPrice >= :minPrice 
+        AND p.productPrice <= :maxPrice
 """)
     fun findAllWithFilters(
         @Param("minPrice") minPrice: Int,
@@ -81,6 +114,13 @@ interface ProductPostRepository : JpaRepository<ProductPost, String> {
     WHERE p.title LIKE :keyword
       AND p.productPrice >= :minPrice
       AND p.productPrice <= :maxPrice
+""", countQuery = """
+    SELECT count( p) 
+    FROM
+        ProductPost p 
+    WHERE p.title LIKE :keyword
+        AND p.productPrice >= :minPrice 
+        AND p.productPrice <= :maxPrice
 """
     )
     fun findByKeywordWithPrice(

--- a/frontend/src/components/posts/Pagination.tsx
+++ b/frontend/src/components/posts/Pagination.tsx
@@ -18,7 +18,8 @@ export default function Pagination({
   if (totalPages <= 1) return null;
 
   const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
-
+  const startPage = currentPage - 3 < 1 ? 0 : currentPage - 3;
+  const endPage = currentPage + 3 > totalPages ? totalPages : currentPage + 3;
   return (
     <div className="flex items-center justify-center space-x-2 mt-6">
       <button
@@ -28,7 +29,7 @@ export default function Pagination({
       >
         이전
       </button>
-      {pageNumbers.map((num) => (
+      {pageNumbers.slice(startPage, endPage).map((num) => (
         <button
           key={num}
           onClick={() => onPageChange(num)}


### PR DESCRIPTION
countQuery의 distict 절을 없애 속도를 개선

필터링 검색의 경우 group by / having절이 created_at의 인덱싱 정렬을 깨트림. 서브쿼리를 이용해 필터링한 productPost의 id만 얻고, 이것을 바탕으로 정렬과 limit 수행

<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
productPost의 필터링 조회와 기본 조회 성능 개선

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
필터링 검색의 경우 group by / having절이 created_at의 인덱싱 정렬을 깨트림.
서브쿼리를 이용해 필터링한 productPost의 id만 얻고, 이것을 바탕으로 정렬과 limit 수행

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->




