### PR TITLE
옥정현/feat 54 메인관리자 관련 기능을 추가, 관리자 회원가입·삭제·조회 구현

### DIFF
--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
@@ -199,9 +199,9 @@ class AdminController(
     @Operation(summary = "관리자 회원가입", description = "superadmin 권한으로 새로운 admin 계정을 생성합니다.")
     @ApiResponses(value = [ApiResponse(responseCode = "200", description = "관리자 회원가입 성공")])
     @SecurityRequirement(name = "cookieAuth")
-    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/signup")
-    fun signUpAdmin(@Valid body: SignUpAdminReqBody): RsData<UserDto> {
+    fun signUpAdmin(@RequestBody @Valid body: SignUpAdminReqBody): RsData<UserDto> {
 
         val newAdmin = adminService.signUpAdmin(
             body.username,

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
@@ -211,4 +211,15 @@ class AdminController(
         )
         return RsData("200-1", "관리자 회원가입 성공.", UserDto(newAdmin))
     }
+
+    @Operation(summary = "관리자 삭제", description = "superadmin 권한으로 특정 admin 계정을 삭제합니다.")
+    @ApiResponses(value = [ApiResponse(responseCode = "204", description = "관리자 삭제 성공")])
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/{adminId}")
+    fun deleteAdmin(@PathVariable adminId: String): RsData<Void> {
+
+        adminService.deleteAdmin(adminId)
+        return RsData("200-1", "관리자 삭제 성공.")
+    }
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
@@ -222,4 +222,14 @@ class AdminController(
         adminService.deleteAdmin(adminId)
         return RsData("200-1", "관리자 삭제 성공.")
     }
+
+    @Operation(summary = "관리자 리스트 조회", description = "등록된 관리자 리스트를 조회합니다.")
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "관리자 리스트 조회 성공")])
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/admins")
+    fun getAdminList(@PageableDefault(size = 10, page = 0) pageable: Pageable): RsData<Page<UserDto>> {
+        val admins: Page<UserDto> = adminService.getAdmins(pageable)
+        return RsData("200-1", "관리자 리스트 조회 성공.", admins)
+    }
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminController.kt
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.*
 import lombok.RequiredArgsConstructor
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -30,7 +30,7 @@ class AdminController(
     private val adminService: AdminService
 ) {
 
-    
+
     data class NoticeReqBody(
         @Parameter(
             description = "공지사항 제목",
@@ -62,7 +62,7 @@ class AdminController(
         return RsData("200-1", "공지사항 등록 성공.", data)
     }
 
-    
+
     data class BanReqBody(val reason: @NotEmpty String)
 
     @Operation(summary = "유저 정지", description = "특정 유저를 정지시킵니다.")
@@ -150,7 +150,7 @@ class AdminController(
         return RsData("200-1", "공지사항 리스트 조회 성공.", notices)
     }
 
-    
+
     data class UpdateNoticeReq(val title: String, val content: String)
 
     @Operation(summary = "공지사항 수정", description = "기존 공지사항을 수정합니다.")
@@ -182,5 +182,33 @@ class AdminController(
         val noticeDto: NoticeResBody = adminService.getNotice(noticeId)
 
         return RsData("200-1", "공지사항 조회 성공.", noticeDto)
+    }
+
+    data class SignUpAdminReqBody(
+        @field:Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문과 숫자만 사용할 수 있습니다.")
+        @field:Size(min = 4, max = 20, message = "아이디는 4~20자 사이여야 합니다.")
+        val username:  String,
+        val password:  String,
+        @field:Size(min = 2, max = 20, message = "닉네임은 2~20자 사이여야 합니다.")
+        val nickname:  String,
+        @field:NotBlank(message = "이메일은 필수 입력값입니다.")
+        @field:Email(message = "올바른 이메일 형식이 아닙니다.")
+        val email: String
+    )
+
+    @Operation(summary = "관리자 회원가입", description = "superadmin 권한으로 새로운 admin 계정을 생성합니다.")
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "관리자 회원가입 성공")])
+    @SecurityRequirement(name = "cookieAuth")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    @PostMapping("/signup")
+    fun signUpAdmin(@Valid body: SignUpAdminReqBody): RsData<UserDto> {
+
+        val newAdmin = adminService.signUpAdmin(
+            body.username,
+            body.password,
+            body.nickname,
+            body.email
+        )
+        return RsData("200-1", "관리자 회원가입 성공.", UserDto(newAdmin))
     }
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
@@ -46,6 +46,22 @@ class AdminService(
         private const val BAN_DURATION_WEIGHT = 7
     }
 
+    fun signUpSuperAdmin(username: String, password: String, nickname: String, email: String): User {
+        return User(
+            username,
+            passwordEncoder.encode(password),
+            email,
+            nickname,
+            "addr",
+            "url",
+            Role.SUPER_ADMIN
+        )
+            .let {
+                userService.deleteAuthenticationCode(it.email)
+                userRepository.save(it)
+            }
+    }
+
 
     fun signUpAdmin(username: String, password: String, nickname: String, email: String): User {
         return User(
@@ -109,6 +125,8 @@ class AdminService(
         get() = userService.userIdentity
 
     private fun isAdmin(admin: User) {
+        if(admin.role == Role.SUPER_ADMIN) return
+
         if (admin.role != Role.ADMIN) {
             throw WrongRoleException(HttpStatus.BAD_REQUEST.toString(), "관리자만 작성할 수 있는 글입니다.")
         }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
@@ -16,6 +16,7 @@ import com.NBE_4_5_2.Team5.domain.user.user.service.UserService
 import com.NBE_4_5_2.Team5.domain.user.user.service.UserValidator
 import com.NBE_4_5_2.Team5.global.exception.notice.NoticeNotFoundException
 import com.NBE_4_5_2.Team5.global.exception.security.WrongRoleException
+import com.NBE_4_5_2.Team5.global.exception.user.AdminNotFoundException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.constraints.NotEmpty
 import lombok.RequiredArgsConstructor
@@ -85,6 +86,18 @@ class AdminService(
             }
     }
 
+    @Transactional
+    fun deleteAdmin(adminId: String) {
+
+        isSuperAdmin(loggedInUser)
+
+        val admin = userRepository.findById(adminId)
+            .orElseThrow { AdminNotFoundException("404","관리자를 찾을 수 없습니다") }
+
+        userRepository.delete(admin)
+    }
+
+
     fun writeNotice(title: @NotEmpty String, content: @NotEmpty String): NoticeResBody {
         isAdmin(loggedInUser)
 
@@ -140,7 +153,7 @@ class AdminService(
 
     private fun isSuperAdmin(admin: User) {
         if (admin.role != Role.SUPER_ADMIN) {
-            throw WrongRoleException(HttpStatus.BAD_REQUEST.toString(), "메인 관리자만 작성할 수 있는 글입니다.")
+            throw WrongRoleException(HttpStatus.BAD_REQUEST.toString(), "메인 관리자만 접근할 수 있습니다.")
         }
     }
 
@@ -221,6 +234,5 @@ class AdminService(
                 NoticeResBody.of(it)
             }
     }
-
 
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
@@ -13,13 +13,11 @@ import com.NBE_4_5_2.Team5.domain.user.user.entity.Role
 import com.NBE_4_5_2.Team5.domain.user.user.entity.User
 import com.NBE_4_5_2.Team5.domain.user.user.repository.UserRepository
 import com.NBE_4_5_2.Team5.domain.user.user.service.UserService
-import com.NBE_4_5_2.Team5.domain.user.user.service.UserValidator
 import com.NBE_4_5_2.Team5.global.exception.notice.NoticeNotFoundException
 import com.NBE_4_5_2.Team5.global.exception.security.WrongRoleException
 import com.NBE_4_5_2.Team5.global.exception.user.AdminNotFoundException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.constraints.NotEmpty
-import lombok.RequiredArgsConstructor
 import lombok.extern.slf4j.Slf4j
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -33,10 +31,8 @@ import java.util.stream.Collectors
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional
 class AdminService(
-    private val userValidator: UserValidator,
     private val banListRepository: BanListRepository,
     private val userRepository: UserRepository,
     private val noticePostRepository: NoticePostRepository,
@@ -84,6 +80,16 @@ class AdminService(
             .let {
                 userRepository.save(it)
             }
+    }
+
+    @Transactional(readOnly = true)
+    fun getAdmins(pageable: Pageable): Page<UserDto> {
+        isSuperAdmin(loggedInUser)
+
+        val adminRoles = listOf(Role.ADMIN)
+        val adminPage: Page<User> = userRepository.findAllByRoleIn(adminRoles, pageable)
+
+        return adminPage.map { user -> UserDto(user) }
     }
 
     @Transactional

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
@@ -68,6 +68,7 @@ class AdminService(
     @Transactional
     fun signUpAdmin(username: String, password: String, nickname: String, email: String): User {
 
+        isSuperAdmin(loggedInUser)
         userService.checkDuplicateAndEmail(username, nickname, email)
 
         return User(
@@ -134,6 +135,12 @@ class AdminService(
 
         if (admin.role != Role.ADMIN) {
             throw WrongRoleException(HttpStatus.BAD_REQUEST.toString(), "관리자만 작성할 수 있는 글입니다.")
+        }
+    }
+
+    private fun isSuperAdmin(admin: User) {
+        if (admin.role != Role.SUPER_ADMIN) {
+            throw WrongRoleException(HttpStatus.BAD_REQUEST.toString(), "메인 관리자만 작성할 수 있는 글입니다.")
         }
     }
 

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/admin/service/AdminService.kt
@@ -13,6 +13,7 @@ import com.NBE_4_5_2.Team5.domain.user.user.entity.Role
 import com.NBE_4_5_2.Team5.domain.user.user.entity.User
 import com.NBE_4_5_2.Team5.domain.user.user.repository.UserRepository
 import com.NBE_4_5_2.Team5.domain.user.user.service.UserService
+import com.NBE_4_5_2.Team5.domain.user.user.service.UserValidator
 import com.NBE_4_5_2.Team5.global.exception.notice.NoticeNotFoundException
 import com.NBE_4_5_2.Team5.global.exception.security.WrongRoleException
 import jakarta.persistence.EntityNotFoundException
@@ -34,6 +35,7 @@ import java.util.stream.Collectors
 @RequiredArgsConstructor
 @Transactional
 class AdminService(
+    private val userValidator: UserValidator,
     private val banListRepository: BanListRepository,
     private val userRepository: UserRepository,
     private val noticePostRepository: NoticePostRepository,
@@ -46,6 +48,7 @@ class AdminService(
         private const val BAN_DURATION_WEIGHT = 7
     }
 
+    @Transactional
     fun signUpSuperAdmin(username: String, password: String, nickname: String, email: String): User {
         return User(
             username,
@@ -62,8 +65,11 @@ class AdminService(
             }
     }
 
-
+    @Transactional
     fun signUpAdmin(username: String, password: String, nickname: String, email: String): User {
+
+        userService.checkDuplicateAndEmail(username, nickname, email)
+
         return User(
             username,
             passwordEncoder.encode(password),
@@ -74,7 +80,6 @@ class AdminService(
             Role.ADMIN
         )
             .let {
-                userService.deleteAuthenticationCode(it.email)
                 userRepository.save(it)
             }
     }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/entity/Role.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/entity/Role.kt
@@ -1,5 +1,5 @@
 package com.NBE_4_5_2.Team5.domain.user.user.entity
 
 enum class Role {
-    ADMIN, USER
+    SUPER_ADMIN, ADMIN, USER
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/entity/User.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/entity/User.kt
@@ -59,7 +59,7 @@ class User() : BaseTime() {
     val wroteComments: MutableList<Comment> = mutableListOf()
 
     val isAdmin: Boolean
-        get() = role == Role.ADMIN
+        get() = role == Role.ADMIN || role == Role.SUPER_ADMIN
 
     var latitude: Float = 0.0F
     var longitude: Float = 0.0F

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/entity/User.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/entity/User.kt
@@ -178,7 +178,11 @@ class User() : BaseTime() {
         get() = memberAuthoritiesAsString.map { SimpleGrantedAuthority(it) }
 
     val memberAuthoritiesAsString: List<String>
-        get() = if (isAdmin) listOf("ROLE_ADMIN") else emptyList()
+        get() = when (role) {
+            Role.SUPER_ADMIN -> listOf("ROLE_SUPER_ADMIN", "ROLE_ADMIN")
+            Role.ADMIN -> listOf("ROLE_ADMIN")
+            else -> emptyList()
+        }
 
     fun addWrittenPost(saved: ProductPost) {
         purchasedProducts.add(saved)

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/repository/UserRepository.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/repository/UserRepository.kt
@@ -2,12 +2,15 @@ package com.NBE_4_5_2.Team5.domain.user.user.repository
 
 import com.NBE_4_5_2.Team5.domain.user.user.entity.Role
 import com.NBE_4_5_2.Team5.domain.user.user.entity.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface UserRepository : JpaRepository<User, String> {
     fun findByUsername(username: String): Optional<User>
     fun findAllByRole(role: Role): List<User?>
+    fun findAllByRoleIn(roles: List<Role>, pageable: Pageable): Page<User>
     fun existsByEmail(email: String): Boolean // 이메일 중복 체크
     fun existsByUsername(username: String): Boolean
     fun existsByNickname(nickname: String): Boolean

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/UserAuthService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/UserAuthService.kt
@@ -21,6 +21,10 @@ class UserAuthService(
             UsernamePasswordAuthenticationToken(user, null, user.authorities)
     }
 
+    fun setLogout() {
+        SecurityContextHolder.clearContext()
+    }
+
     fun getRealActor(actor: User): User {
         return userService.getUserById(actor.id).get()
     }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/UserService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/UserService.kt
@@ -10,11 +10,11 @@ import com.NBE_4_5_2.Team5.domain.user.user.entity.Role
 import com.NBE_4_5_2.Team5.domain.user.user.entity.User
 import com.NBE_4_5_2.Team5.domain.user.user.repository.UserRepository
 import com.NBE_4_5_2.Team5.domain.user.user.service.email.EmailService
-import com.NBE_4_5_2.Team5.global.rq.Rq
 import com.NBE_4_5_2.Team5.global.exception.ServiceException
 import com.NBE_4_5_2.Team5.global.exception.security.AuthenticationNotValidException
 import com.NBE_4_5_2.Team5.global.exception.security.TokenNotFoundException
 import com.NBE_4_5_2.Team5.global.exception.user.UserNotFoundException
+import com.NBE_4_5_2.Team5.global.rq.Rq
 import com.NBE_4_5_2.Team5.global.security.SecurityUser
 import jakarta.transaction.Transactional
 import org.springframework.security.authentication.AnonymousAuthenticationToken
@@ -303,8 +303,20 @@ class UserService(
             ?: throw ServiceException("400-1", "인증코드가 틀렸습니다.")
     }
 
+    /**
+     * 요청 이메일을 key 값으로 인증 코드를 redis에 저장
+     * */
+    fun saveAuthenticationCode(email: String, code: String) {
+        emailService.saveAuthenticationCode(email, code)
+    }
+
     // 관리자 유저 한명 반환
     val adminUsers: User
         get() = userRepository.findAllByRole(Role.ADMIN)
             .firstOrNull() ?: throw UserNotFoundException("404", "관리자 유저가 없습니다.")
+
+    fun checkDuplicateAndEmail(username: String, nickname: String, email: String) {
+        userValidator.duplicate(username, nickname)
+        userValidator.emailVerified(email)
+    }
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/email/EmailService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/email/EmailService.kt
@@ -117,12 +117,12 @@ class EmailService(
      * @throws ServiceException 반송 이메일이 확인된 경우 "이메일 발송에 실패했습니다." 메시지와 함께 예외 발생
      */
     fun checkBouncedEmail(email: String) {
-        bouncedEmailService.checkBouncedEmail(email)
-            .takeIf { !it }
-            .also {
-                redisTemplate.delete(createEmailKey(email))
-                throw ServiceException("404-1", "존재하지않는 이메일입니다.")
-            }
+        val isExistEmail = bouncedEmailService.checkBouncedEmail(email)
+
+        if (!isExistEmail) {
+            redisTemplate.delete(createEmailKey(email))
+            throw ServiceException("404-1", "존재하지않는 이메일입니다.")
+        }
     }
 
     /**

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/email/service/BouncedEmailService.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/user/service/email/service/BouncedEmailService.kt
@@ -19,36 +19,27 @@ class BouncedEmailService(
     }
 
     /**
-     * 발송된 이메일 주소가 존재하는 이메일인지 확인
-     * 메일함으로 반송 메일이 오기까지 대기하기 위해 Thread.sleep 적용
+     * 발송된 이메일 주소가 존재하는지 확인합니다.
+     * 메일함으로 반송 메일이 도착하기까지 대기하기 위해 sleep 적용.
      *
-     * @param email 발송되었는지 확인할 이메일
-     * @return 메일함에 해당 이메일로 반송된 메일이 존재할 경우 false, 없으면 true
+     * @param email 확인할 이메일 주소
+     * @return 해당 이메일로 반송된 메일이 존재하면 false, 없으면 true
      */
     fun checkBouncedEmail(email: String): Boolean {
         try {
-
-            // gmail에 반송된 메일이 도착하기까지 3초 대기
+            // 반송 메일이 도착할 시간을 기다립니다 (3초)
             timeProvider.sleep(3000)
-
-            // 현재시간 - 2분 (최근 2분 내에 도착한 메일만 확인하기 위해 사용)
+            val emailFolder = getEmailFolder()
+            // 현재 시간 - untilTime (예를 들어 최근 2분 내 도착한 메일만 확인)
             val untilTime = LocalDateTime.now().minusSeconds(pop3.untilTime.toLong())
 
-            // 메일함의 메일을 하나씩 확인
             for (message in emailFolder.messages) {
-                // 해당 메일이 도착한 시간을 확인
                 val messageTime = getMessageTime(message)
-
-                // 해당 메일 도착 시간이 2분 이내라면
-                if (untilTime.isBefore(messageTime)) {
-
-                    // 반송된 이메일에 대한 수신자 정보를 담은 헤더를 가져옴
-                    message.getHeader(FAILED_RECIPIENTS_HEADER)?.let {
-
-                        // 사용자가 요청한 email과 반송된 이메일의 수신자가 같을 경우
-                        if (it[0] == email) {
+                if (untilTime.isBefore(messageTime)) { // untilTime 이후에 도착한 메일이라면
+                    message.getHeader(FAILED_RECIPIENTS_HEADER)?.let { recipients ->
+                        if (recipients.isNotEmpty() && recipients[0] == email) {
                             try {
-                                // 반송된 이메일을 메일함에서 삭제 후 메일함을 닫음
+                                // 반송된 이메일 삭제
                                 message.setFlag(Flags.Flag.DELETED, true)
                                 emailFolder.close(true)
                             } catch (e: MessagingException) {
@@ -56,50 +47,39 @@ class BouncedEmailService(
                             }
                         }
                     }
+                    // 폴더가 닫혔다면 반송 메일을 찾았다고 판단
+                    if (!emailFolder.isOpen) return false
                 }
-                // 폴더를 닫았다면 반송 메일을 찾고 삭제했다고 판단하여 false를 반환함
-                if (!emailFolder.isOpen) return false
             }
         } catch (e: Exception) {
             e.printStackTrace()
             throw ServiceException("500", "반송 메일 확인 중 오류가 발생했습니다.")
         }
-        return true // 반송메일이 존재하지 않는 경우 true 반환
+        return true
     }
 
-    /**
-     * 해당 메세지의 발송 시간을 LocalDateTime으로 변환하여 반환
-     */
     @Throws(MessagingException::class)
     fun getMessageTime(message: Message): LocalDateTime =
-        message
-            .sentDate
+        message.sentDate
             .toInstant()
             .atZone(ZoneId.systemDefault())
             .toLocalDateTime()
 
-
-    /**
-     * 실제 gmail의 메일함을 가져오는 메소드
-     * */
-    val emailFolder: Folder
-        get() {
-            try {
-                val properties = Properties().apply {
-                    put("mail.pop3.host", pop3.host)
-                    put("mail.pop3.port", pop3.port)
-                    put("mail.pop3.starttls.enable", "true")
-                }
-
-                val store = Session.getDefaultInstance(properties)
-                    .getStore(pop3.protocol).also{
-                        it.connect(pop3.host, pop3.username, pop3.password)
-                    }
-
-                return store.getFolder(pop3.folder).also { it.open(Folder.READ_WRITE) }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                throw ServiceException("404-1", "반송 메일을 찾기 못했습니다.")
+    fun getEmailFolder(): Folder {
+        try {
+            val properties = Properties().apply {
+                put("mail.pop3.host", pop3.host)
+                put("mail.pop3.port", pop3.port)
+                put("mail.pop3.starttls.enable", "true")
             }
+            val emailSession = Session.getDefaultInstance(properties)
+            val store: Store = emailSession.getStore(pop3.protocol).apply {
+                connect(pop3.host, pop3.username, pop3.password)
+            }
+            return store.getFolder(pop3.folder).also { it.open(Folder.READ_WRITE) }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw ServiceException("404-1", "반송 메일을 찾기 못했습니다.")
         }
+    }
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/global/exception/user/AdminNotFoundException.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/global/exception/user/AdminNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.NBE_4_5_2.Team5.global.exception.user
+
+import com.NBE_4_5_2.Team5.global.exception.security.SecurityException
+
+class AdminNotFoundException(code: String, message: String) :
+    SecurityException(code, message)

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/global/init/BaseInitData.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/global/init/BaseInitData.kt
@@ -1,6 +1,5 @@
 package com.NBE_4_5_2.Team5.global.init
 
-import com.NBE_4_5_2.Team5.domain.notification.entity.Notification
 import com.NBE_4_5_2.Team5.domain.post.category.entity.Category
 import com.NBE_4_5_2.Team5.domain.post.category.repository.CategoryRepository
 import com.NBE_4_5_2.Team5.domain.post.post.entity.ProductCategory
@@ -19,7 +18,6 @@ import com.NBE_4_5_2.Team5.domain.user.user.service.UserService
 import com.NBE_4_5_2.Team5.domain.user.user.service.email.EmailService
 import com.NBE_4_5_2.Team5.global.aspect.product.ProductMetaDataNames
 import com.NBE_4_5_2.Team5.infrastructure.kafka.KafkaConsumer
-import com.NBE_4_5_2.Team5.infrastructure.kafka.KafkaNotificationProducerService
 import jakarta.transaction.Transactional
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -29,8 +27,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.Order
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
-import java.io.IOException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -86,19 +82,20 @@ class BaseInitData(
     @Order(6)
     fun applicationRunner6(): ApplicationRunner =
         ApplicationRunner { _ -> self.metadata() }
-    fun metadata(){
-        if(productMetadataRepository.findByName(ProductMetaDataNames.PRODUCT_TOTAL_COUNT)!=null)
-        productMetadataRepository.save(ProductMetadata(ProductMetaDataNames.PRODUCT_TOTAL_COUNT, "0"))
+
+    fun metadata() {
+        if (productMetadataRepository.findByName(ProductMetaDataNames.PRODUCT_TOTAL_COUNT) != null)
+            productMetadataRepository.save(ProductMetadata(ProductMetaDataNames.PRODUCT_TOTAL_COUNT, "0"))
     }
 
     fun noticePing() {
         val executor = Executors.newSingleThreadScheduledExecutor()
 
         executor.scheduleAtFixedRate({
-            try{
+            try {
                 kafkaConsumer.ping()
 
-            }catch (e:Throwable){
+            } catch (e: Throwable) {
 
             }
 
@@ -113,6 +110,7 @@ class BaseInitData(
         emailService.saveAuthenticationCode("user2@gmail.com", "verified")
         emailService.saveAuthenticationCode("user3@gmail.com", "verified")
         emailService.saveAuthenticationCode("user4@gmail.com", "verified")
+        emailService.saveAuthenticationCode("admin1@gmail.com", "verified")
         emailService.saveAuthenticationCode("admin2@gmail.com", "verified")
 
         val baseUrl =
@@ -126,6 +124,7 @@ class BaseInitData(
         userService.createUser("user2", "user21234@", "user2@gmail.com", "user2", "서울시 강서구", imageUrl)
         userService.createUser("user3", "user31234@", "user3@gmail.com", "user3", "서울시 광진구", imageUrl)
 
+        adminService.signUpSuperAdmin("admin1", "password1", "admin1", "admin1@gmail.com")
         adminService.signUpAdmin("admin2", "password2", "admin2", "admin2@gmail.com")
         adminService.signUpAdmin("user4", "user41234@", "admin4", "user4@gmail.com")
     }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/global/init/BaseInitData.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/global/init/BaseInitData.kt
@@ -14,6 +14,7 @@ import com.NBE_4_5_2.Team5.domain.user.admin.service.AdminService
 import com.NBE_4_5_2.Team5.domain.user.user.entity.Role
 import com.NBE_4_5_2.Team5.domain.user.user.entity.User
 import com.NBE_4_5_2.Team5.domain.user.user.repository.UserRepository
+import com.NBE_4_5_2.Team5.domain.user.user.service.UserAuthService
 import com.NBE_4_5_2.Team5.domain.user.user.service.UserService
 import com.NBE_4_5_2.Team5.domain.user.user.service.email.EmailService
 import com.NBE_4_5_2.Team5.global.aspect.product.ProductMetaDataNames
@@ -46,6 +47,9 @@ class BaseInitData(
     @Value("\${custom.server.host}")
     private val serverHost: String
 ) {
+    @Autowired
+    private lateinit var userAuthService: UserAuthService
+
     @Autowired
     private lateinit var productMetadataRepository: ProductMetadataRepository
 
@@ -124,9 +128,12 @@ class BaseInitData(
         userService.createUser("user2", "user21234@", "user2@gmail.com", "user2", "서울시 강서구", imageUrl)
         userService.createUser("user3", "user31234@", "user3@gmail.com", "user3", "서울시 광진구", imageUrl)
 
-        adminService.signUpSuperAdmin("admin1", "password1", "admin1", "admin1@gmail.com")
+        val superAdmin = adminService.signUpSuperAdmin("admin1", "password1", "admin1", "admin1@gmail.com")
+
+        userAuthService.setLogin(superAdmin)
         adminService.signUpAdmin("admin2", "password2", "admin2", "admin2@gmail.com")
         adminService.signUpAdmin("user4", "user41234@", "admin4", "user4@gmail.com")
+        userAuthService.setLogout()
     }
 
     @Transactional

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/global/init/BaseInitData.kt
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/global/init/BaseInitData.kt
@@ -119,7 +119,7 @@ class BaseInitData(
 
         val baseUrl =
             if (serverHost.startsWith("backend.nbe-4-5-5-team5.shop"))
-                "https://%s/images".formatted(serverHost)
+                "https://${serverHost}/images"
             else
                 "http://localhost:8080/images/"
         val imageUrl = baseUrl + "default_profile" + ".jpg" // 하나의 이미지만 사용
@@ -209,7 +209,7 @@ class BaseInitData(
         // 관리자 계정 우선, 없으면 첫 번째 유저
         val users = userRepository.findAll()
         val adminUser: User = users
-            .firstOrNull { it.role == Role.ADMIN }
+            .firstOrNull { it.role == Role.ADMIN || it.role == Role.SUPER_ADMIN }
             ?: users.firstOrNull()
             ?: return  // 유저 자체가 하나도 없으면 초기화 스킵
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -82,9 +82,8 @@ spring:
       mail:
         smtp:
           auth: true
-          starttls:
-            enable: true
-            required: true
+          starttls-enable: true
+          starttls-required: true
           connection-timeout: 5000                     # 클라이언트 -> SMTP 서버 연결 대기 시간
           timeout: 5000                                # 클라이언트 <- SMTP 서버 응답 대기 시간
           write-timeout: 5000                          # 클라이언트 작업 완료 대기 시간

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/chat/controller/ChatRoomControllerTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/chat/controller/ChatRoomControllerTest.kt
@@ -401,7 +401,9 @@ class ChatRoomControllerTest {
                 "User not found"
             )
         }
-        org.junit.jupiter.api.Assertions.assertEquals(Role.ADMIN, admin.role)
+        org.junit.jupiter.api.Assertions.assertTrue(
+            admin.role == Role.ADMIN || admin.role == Role.SUPER_ADMIN
+        )
     } // Given
     // When
     // Then

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
@@ -334,7 +334,6 @@ internal class AdminControllerTest(
         )
 
         // then
-
         result
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
@@ -342,6 +341,82 @@ internal class AdminControllerTest(
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.username").value("admin3"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("관리자3"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("admin3@gmail.com"))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun signUpAdminWithoutEmailAuthentication() {
+        // given
+
+        val cookieMap = login("admin1", "password1") // 메인 관리자로 로그인
+        // 이메일 인증을 하지 않은 상태
+
+        // when: 인증이 완료되지 않은 이메일로 관리자 회원가입 시도
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/admin/signup")
+                .content(
+                    """
+                {
+                    "username": "admin3",
+                    "password": "admin3@",
+                    "nickname": "관리자3",
+                    "email": "admin3@gmail.com"
+                }
+                """.trimIndent()
+                )
+                .contentType("application/json")
+                .characterEncoding("utf-8")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        )
+
+        // then: 이메일 인증 미완료 오류
+        result.andExpect(MockMvcResultMatchers.status().isConflict)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("409"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("이메일 인증이 완료되지 않았습니다. 인증 후 다시 시도해주세요."))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun signUpAdminWithInvalidInput() {
+        // given
+        // 메인 관리자로 로그인 (SUPER_ADMIN 권한)
+        val cookieMap = login("admin1", "password1")
+        val username: String = "admin!@#" // 특수문자 포함되어 유효성 검증에 실패
+        val password: String = "admin3@"
+        val nickname: String = "1" // 닉네임이 2글자 미만
+        val email: String = "invalid-email" // 올바른 이메일 형식 아님
+
+        val invalidContent = """
+        {
+            "username": "${username}",  
+            "password": "${password}",
+            "nickname": "${nickname}",         
+            "email": "${email}" 
+        }
+    """.trimIndent()
+
+        // when: 잘못된 입력값으로 관리자 회원가입 시도
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/admin/signup")
+                .content(invalidContent)
+                .contentType("application/json")
+                .characterEncoding("utf-8")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        )
+
+        // then: 유효성 검증 실패로 400 Bad Request 발생
+        result
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("400-1"))
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.message").value(
+                    """
+                        email : 올바른 이메일 형식이 아닙니다.
+                        nickname : 닉네임은 2~20자 사이여야 합니다.
+                        username : 아이디는 영문과 숫자만 사용할 수 있습니다.
+                    """.trimIndent().trimEnd()
+                )
+            )
     }
 
 

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
@@ -10,15 +10,18 @@ import com.NBE_4_5_2.Team5.global.exception.user.AdminNotFoundException
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.Cookie
 import org.assertj.core.api.Assertions.*
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.*
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.nio.charset.StandardCharsets
 import java.util.*
 
 @SpringBootTest
@@ -55,7 +58,7 @@ internal class AdminControllerTest(
         // when
         // API 호출
         val perform = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/notices")
+            post("/api/admin/notices")
                 .content(
                     """
 				{
@@ -78,21 +81,21 @@ internal class AdminControllerTest(
 
         // then
         perform
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.handler().handlerType(AdminController::class.java))
-            .andExpect(MockMvcResultMatchers.handler().methodName("writeNotice"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("공지사항 등록 성공."))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(notice.id))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").value(notice.title))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value(notice.content))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.admin.id").value(admin.id))
+            .andExpect(status().isOk())
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("writeNotice"))
+            .andExpect(jsonPath("$.code").value("200-1"))
+            .andExpect(jsonPath("$.message").value("공지사항 등록 성공."))
+            .andExpect(jsonPath("$.data.id").value(notice.id))
+            .andExpect(jsonPath("$.data.title").value(notice.title))
+            .andExpect(jsonPath("$.data.content").value(notice.content))
+            .andExpect(jsonPath("$.data.admin.id").value(admin.id))
     }
 
     @Throws(Exception::class)
     private fun login(username: String, password: String): Map<String, Cookie> {
         val cookies = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/users/login")
+            post("/api/users/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -103,7 +106,7 @@ internal class AdminControllerTest(
 					""".trimIndent()
                 )
         )
-            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(status().isOk())
             .andReturn().response.cookies
 
         val cookieMap: MutableMap<String, Cookie> = HashMap()
@@ -127,7 +130,7 @@ internal class AdminControllerTest(
             .orElseThrow { RuntimeException() }
 
         val perform = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/users/${user.id}/ban")
+            post("/api/admin/users/${user.id}/ban")
                 .content(
                     """
 				{
@@ -148,15 +151,15 @@ internal class AdminControllerTest(
         val foundedUser = userService.getUserByUsername("user1")
 
         perform
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.handler().handlerType(AdminController::class.java))
-            .andExpect(MockMvcResultMatchers.handler().methodName("banUser"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("유저 정지 성공"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.banListId").value(banList.id))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.reason").value(banList.reason))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(banList.bannedUser.id))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.banCount").value(foundedUser.get().blockedCount))
+            .andExpect(status().isOk())
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("banUser"))
+            .andExpect(jsonPath("$.code").value("200-1"))
+            .andExpect(jsonPath("$.message").value("유저 정지 성공"))
+            .andExpect(jsonPath("$.data.banListId").value(banList.id))
+            .andExpect(jsonPath("$.data.reason").value(banList.reason))
+            .andExpect(jsonPath("$.data.userId").value(banList.bannedUser.id))
+            .andExpect(jsonPath("$.data.banCount").value(foundedUser.get().blockedCount))
         assertThat(foundedUser.get().blocked).isTrue()
         assertThat(foundedUser.get().blockedCount).isEqualTo(1)
     }
@@ -174,7 +177,7 @@ internal class AdminControllerTest(
             .items[0].id
 
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.delete("/api/admin/posts/$id")
+            delete("/api/admin/posts/$id")
                 .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
         )
 
@@ -185,9 +188,9 @@ internal class AdminControllerTest(
             .isInstanceOf(ProductPostNotFoundException::class.java)
 
         result
-            .andExpect(MockMvcResultMatchers.status().isNoContent)
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("204-1"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("게시글 삭제 성공."))
+            .andExpect(status().isNoContent)
+            .andExpect(jsonPath("$.code").value("204-1"))
+            .andExpect(jsonPath("$.message").value("게시글 삭제 성공."))
     }
 
     @Test
@@ -200,7 +203,7 @@ internal class AdminControllerTest(
         // when
         // API 호출
         val perform = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/notices")
+            post("/api/admin/notices")
                 .content(
                     """
 				{
@@ -223,13 +226,13 @@ internal class AdminControllerTest(
 
         // then
         perform
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("공지사항 등록 성공."))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(notice.id))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").value(notice.title))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value(notice.content))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.admin.id").value(admin.id))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200-1"))
+            .andExpect(jsonPath("$.message").value("공지사항 등록 성공."))
+            .andExpect(jsonPath("$.data.id").value(notice.id))
+            .andExpect(jsonPath("$.data.title").value(notice.title))
+            .andExpect(jsonPath("$.data.content").value(notice.content))
+            .andExpect(jsonPath("$.data.admin.id").value(admin.id))
     }
 
     @Test
@@ -245,7 +248,7 @@ internal class AdminControllerTest(
             .orElseThrow { RuntimeException() }
 
         val perform = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/users/${user.id}/ban")
+            post("/api/admin/users/${user.id}/ban")
                 .content(
                     """
 				{
@@ -266,15 +269,15 @@ internal class AdminControllerTest(
         val foundedUser = userService.getUserByUsername("user1")
 
         perform
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.handler().handlerType(AdminController::class.java))
-            .andExpect(MockMvcResultMatchers.handler().methodName("banUser"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("유저 정지 성공"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.banListId").value(banList.id))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.reason").value(banList.reason))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(banList.bannedUser.id))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.banCount").value(foundedUser.get().blockedCount))
+            .andExpect(status().isOk())
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("banUser"))
+            .andExpect(jsonPath("$.code").value("200-1"))
+            .andExpect(jsonPath("$.message").value("유저 정지 성공"))
+            .andExpect(jsonPath("$.data.banListId").value(banList.id))
+            .andExpect(jsonPath("$.data.reason").value(banList.reason))
+            .andExpect(jsonPath("$.data.userId").value(banList.bannedUser.id))
+            .andExpect(jsonPath("$.data.banCount").value(foundedUser.get().blockedCount))
         assertThat(foundedUser.get().blocked).isTrue()
         assertThat(foundedUser.get().blockedCount).isEqualTo(1)
     }
@@ -292,7 +295,7 @@ internal class AdminControllerTest(
             .items[0].id
 
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.delete("/api/admin/posts/$id")
+            delete("/api/admin/posts/$id")
                 .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
         )
 
@@ -303,9 +306,9 @@ internal class AdminControllerTest(
             .isInstanceOf(ProductPostNotFoundException::class.java)
 
         result
-            .andExpect(MockMvcResultMatchers.status().isNoContent)
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("204-1"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("게시글 삭제 성공."))
+            .andExpect(status().isNoContent)
+            .andExpect(jsonPath("$.code").value("204-1"))
+            .andExpect(jsonPath("$.message").value("게시글 삭제 성공."))
     }
 
     @Test
@@ -318,7 +321,7 @@ internal class AdminControllerTest(
 
         //when
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/signup")
+            post("/api/admin/signup")
                 .content(
                     """
 				{
@@ -336,12 +339,12 @@ internal class AdminControllerTest(
 
         // then
         result
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("관리자 회원가입 성공."))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.username").value("admin3"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("관리자3"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("admin3@gmail.com"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200-1"))
+            .andExpect(jsonPath("$.message").value("관리자 회원가입 성공."))
+            .andExpect(jsonPath("$.data.username").value("admin3"))
+            .andExpect(jsonPath("$.data.nickname").value("관리자3"))
+            .andExpect(jsonPath("$.data.email").value("admin3@gmail.com"))
     }
 
     @Test
@@ -354,7 +357,7 @@ internal class AdminControllerTest(
 
         // when: 인증이 완료되지 않은 이메일로 관리자 회원가입 시도
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/signup")
+            post("/api/admin/signup")
                 .content(
                     """
                 {
@@ -371,9 +374,9 @@ internal class AdminControllerTest(
         )
 
         // then: 이메일 인증 미완료 오류
-        result.andExpect(MockMvcResultMatchers.status().isConflict)
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("409"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("이메일 인증이 완료되지 않았습니다. 인증 후 다시 시도해주세요."))
+        result.andExpect(status().isConflict)
+            .andExpect(jsonPath("$.code").value("409"))
+            .andExpect(jsonPath("$.message").value("이메일 인증이 완료되지 않았습니다. 인증 후 다시 시도해주세요."))
     }
 
     @Test
@@ -398,7 +401,7 @@ internal class AdminControllerTest(
 
         // when: 잘못된 입력값으로 관리자 회원가입 시도
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/signup")
+            post("/api/admin/signup")
                 .content(invalidContent)
                 .contentType("application/json")
                 .characterEncoding("utf-8")
@@ -407,10 +410,10 @@ internal class AdminControllerTest(
 
         // then: 유효성 검증 실패로 400 Bad Request 발생
         result
-            .andExpect(MockMvcResultMatchers.status().isBadRequest())
-            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("400-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("400-1"))
             .andExpect(
-                MockMvcResultMatchers.jsonPath("$.message").value(
+                jsonPath("$.message").value(
                     """
                         email : 올바른 이메일 형식이 아닙니다.
                         nickname : 닉네임은 2~20자 사이여야 합니다.
@@ -431,7 +434,7 @@ internal class AdminControllerTest(
 
         // 삭제 대상 관리자 신규 생성
         val signupResult = mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/admin/signup")
+            post("/api/admin/signup")
                 .content(
                     """
                     {
@@ -452,7 +455,7 @@ internal class AdminControllerTest(
 
         // when: 생성된 관리자 계정을 삭제 요청합니다.
         val deleteResult = mockMvc.perform(
-            MockMvcRequestBuilders.delete("/api/admin/$newAdminId")
+            delete("/api/admin/$newAdminId")
                 .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
         ).andReturn()
 
@@ -467,4 +470,84 @@ internal class AdminControllerTest(
         assertThat(json.get("message").asText()).isEqualTo("관리자 삭제 성공.")
         assertThat(deleteResult.response.status).isEqualTo(200)
     }
+
+    @Throws(Exception::class)
+    private fun createAdminRequest(
+        username: String,
+        password: String,
+        email: String,
+        nickname: String,
+        cookieMap: Map<String, Cookie>
+    ): ResultActions {
+        return mockMvc.perform(
+            post("/api/admin/signup")
+                .content(
+                    """
+                {
+                  "username": "$username",
+                  "password": "$password",
+                  "nickname": "$nickname",
+                  "email": "$email"
+                }
+                """.trimIndent()
+                )
+                .contentType(MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        ).andDo(print())
+    }
+
+
+    @Test
+    @Throws(Exception::class)
+    fun getAdminListBySuperAdmin() {
+        // given
+        // SUPER_ADMIN 계정으로 로그인 (admin1, password1)
+        val cookieMap = login("admin1", "password1")
+
+        // 테스트를 위해 신규 관리자 계정을 생성합니다.
+        userService.saveAuthenticationCode("adminA@gmail.com", "verified")
+        userService.saveAuthenticationCode("adminB@gmail.com", "verified")
+        userService.saveAuthenticationCode("adminC@gmail.com", "verified")
+
+        // 생성할 관리자 3명의 데이터
+        val adminData = listOf(
+            Triple("adminA", "adminA@", "adminA@gmail.com") to "관리자 A",
+            Triple("adminB", "adminB@", "adminB@gmail.com") to "관리자 B",
+            Triple("adminC", "adminC@", "adminC@gmail.com") to "관리자 C"
+        )
+
+        // 각 관리자 생성 요청 실행 (쿠키 정보를 함께 전달)
+        adminData.forEach { (credentials, nickname) ->
+            val (username, password, email) = credentials
+            createAdminRequest(username, password, email, nickname, cookieMap)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.code").value("200-1"))
+                .andExpect(jsonPath("$.message").value("관리자 회원가입 성공."))
+        }
+
+        // when: 관리자 리스트 조회 API 호출 (페이지 0, 사이즈 10)
+        val mvcResult = mockMvc.perform(
+            get("/api/admin/admins")
+                .param("page", "0")
+                .param("size", "10")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        ).andReturn()
+
+        // then: 응답 JSON 검증
+        val json = objectMapper.readTree(mvcResult.response.contentAsString)
+        assertThat(json.get("code").asText()).isEqualTo("200-1")
+        assertThat(json.get("message").asText()).isEqualTo("관리자 리스트 조회 성공.")
+
+        val dataNode = json.get("data")
+        assertThat(dataNode.get("content").isArray()).isTrue
+        assertThat(dataNode.get("content").size()).isGreaterThanOrEqualTo(1)
+
+        dataNode.get("content").forEach { adminNode ->
+            val role = adminNode.get("role").asText()
+            assertThat(role.equals("ADMIN", ignoreCase = true) || role.equals("SUPER_ADMIN", ignoreCase = true))
+                .withFailMessage("관리자 리스트 항목의 role이 ADMIN 또는 SUPER_ADMIN 이어야 합니다. 현재 role: $role")
+                .isTrue
+        }
+    }
+
 }

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
@@ -6,9 +6,10 @@ import com.NBE_4_5_2.Team5.domain.user.admin.service.AdminService
 import com.NBE_4_5_2.Team5.domain.user.user.service.UserService
 import com.NBE_4_5_2.Team5.global.config.BaseTestConfig
 import com.NBE_4_5_2.Team5.global.exception.post.product.ProductPostNotFoundException
+import com.NBE_4_5_2.Team5.global.exception.user.AdminNotFoundException
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.Cookie
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
@@ -156,8 +157,8 @@ internal class AdminControllerTest(
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.reason").value(banList.reason))
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(banList.bannedUser.id))
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.banCount").value(foundedUser.get().blockedCount))
-        Assertions.assertThat(foundedUser.get().blocked).isTrue()
-        Assertions.assertThat(foundedUser.get().blockedCount).isEqualTo(1)
+        assertThat(foundedUser.get().blocked).isTrue()
+        assertThat(foundedUser.get().blockedCount).isEqualTo(1)
     }
 
     @Test
@@ -180,7 +181,7 @@ internal class AdminControllerTest(
         // then
 
         // 삭제된 product post 조회 시 오류 발생해야 한다.
-        Assertions.assertThatThrownBy { productPostService.getPost(id) }
+        assertThatThrownBy { productPostService.getPost(id) }
             .isInstanceOf(ProductPostNotFoundException::class.java)
 
         result
@@ -274,8 +275,8 @@ internal class AdminControllerTest(
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.reason").value(banList.reason))
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(banList.bannedUser.id))
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.banCount").value(foundedUser.get().blockedCount))
-        Assertions.assertThat(foundedUser.get().blocked).isTrue()
-        Assertions.assertThat(foundedUser.get().blockedCount).isEqualTo(1)
+        assertThat(foundedUser.get().blocked).isTrue()
+        assertThat(foundedUser.get().blockedCount).isEqualTo(1)
     }
 
     @Test
@@ -298,7 +299,7 @@ internal class AdminControllerTest(
         // then
 
         // 삭제된 product post 조회 시 오류 발생해야 한다.
-        Assertions.assertThatThrownBy { productPostService.getPost(id) }
+        assertThatThrownBy { productPostService.getPost(id) }
             .isInstanceOf(ProductPostNotFoundException::class.java)
 
         result
@@ -381,10 +382,10 @@ internal class AdminControllerTest(
         // given
         // 메인 관리자로 로그인 (SUPER_ADMIN 권한)
         val cookieMap = login("admin1", "password1")
-        val username: String = "admin!@#" // 특수문자 포함되어 유효성 검증에 실패
-        val password: String = "admin3@"
-        val nickname: String = "1" // 닉네임이 2글자 미만
-        val email: String = "invalid-email" // 올바른 이메일 형식 아님
+        val username = "admin!@#" // 특수문자 포함되어 유효성 검증에 실패
+        val password = "admin3@"
+        val nickname = "1" // 닉네임이 2글자 미만
+        val email = "invalid-email" // 올바른 이메일 형식 아님
 
         val invalidContent = """
         {
@@ -419,5 +420,51 @@ internal class AdminControllerTest(
             )
     }
 
+    @Test
+    @Throws(Exception::class)
+    fun deleteAdminBySuperAdmin() {
+        // given
+        // SUPER_ADMIN 로그인
+        val cookieMap = login("admin1", "password1")
 
+        userService.saveAuthenticationCode("adminToDelete@gmail.com", "verified")
+
+        // 삭제 대상 관리자 신규 생성
+        val signupResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/admin/signup")
+                .content(
+                    """
+                    {
+                        "username": "adminToDelete",
+                        "password": "adminToDelete@",
+                        "nickname": "삭제대상관리자",
+                        "email": "adminToDelete@gmail.com"
+                    }
+                    """.trimIndent()
+                )
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        ).andReturn()
+
+        val newAdminId = objectMapper.readTree(signupResult.response.contentAsString)
+            .get("data").get("id").asText()
+
+        // when: 생성된 관리자 계정을 삭제 요청합니다.
+        val deleteResult = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/$newAdminId")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        ).andReturn()
+
+        // then: 삭제 후 해당 관리자 계정을 조회하면 AdminNotFoundException 발생
+        assertThatThrownBy {
+            userService.getUserByUsername("adminToDelete")
+                .orElseThrow { AdminNotFoundException("404", "관리자를 찾을 수 없습니다") }
+        }.isInstanceOf(AdminNotFoundException::class.java)
+
+        val json = objectMapper.readTree(deleteResult.response.contentAsString)
+        assertThat(json.get("code").asText()).isEqualTo("200-1")
+        assertThat(json.get("message").asText()).isEqualTo("관리자 삭제 성공.")
+        assertThat(deleteResult.response.status).isEqualTo(200)
+    }
 }

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
@@ -306,4 +306,44 @@ internal class AdminControllerTest(
             .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("204-1"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("게시글 삭제 성공."))
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun signUpAdminBySuperAdmin() {
+        //given
+        // 메인 관리자로 로그인
+        val cookieMap = login("admin1", "password1")
+        userService.saveAuthenticationCode("admin3@gmail.com", "verify") // 이메일 인증이 완료되었다 가정
+
+        //when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/signup")
+                .content(
+                    """
+				{
+					"username": "admin3",
+                    "password": "admin3@",
+                    "nickname": "관리자3",
+                    "email": "admin3@gmail.com"
+				}
+				""".trimIndent()
+                )
+                .contentType("application/json")
+                .characterEncoding("utf-8")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        )
+
+        // then
+
+        result
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("관리자 회원가입 성공."))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.username").value("admin3"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("관리자3"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("admin3@gmail.com"))
+    }
+
+
 }

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
@@ -313,11 +313,11 @@ internal class AdminControllerTest(
         //given
         // 메인 관리자로 로그인
         val cookieMap = login("admin1", "password1")
-        userService.saveAuthenticationCode("admin3@gmail.com", "verify") // 이메일 인증이 완료되었다 가정
+        userService.saveAuthenticationCode("admin3@gmail.com", "verified") // 이메일 인증이 완료되었다 가정
 
         //when
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.delete("/api/admin/signup")
+            MockMvcRequestBuilders.post("/api/admin/signup")
                 .content(
                     """
 				{
@@ -330,7 +330,6 @@ internal class AdminControllerTest(
                 )
                 .contentType("application/json")
                 .characterEncoding("utf-8")
-                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
                 .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
         )
 

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/admin/controller/AdminControllerTest.kt
@@ -188,4 +188,122 @@ internal class AdminControllerTest(
             .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("204-1"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("게시글 삭제 성공."))
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun writeNoticeBySuperAdmin() {
+        //given
+        // 메인 관리자로 로그인
+        val cookieMap = login("admin1", "password1")
+
+        // when
+        // API 호출
+        val perform = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/admin/notices")
+                .content(
+                    """
+				{
+					"title": "공지 제목",
+					"content": "공지 내용"
+				}
+				""".trimIndent()
+                )
+                .contentType("application/json")
+                .characterEncoding("utf-8")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        )
+
+        val id = objectMapper.readTree(perform.andReturn().response.contentAsString)["data"]["id"].asText()
+
+        val notice = adminService.getNotice(id)
+
+        val admin = userService.getUserByUsername("admin1")
+            .orElseThrow { RuntimeException() }
+
+        // then
+        perform
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("공지사항 등록 성공."))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(notice.id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").value(notice.title))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value(notice.content))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.admin.id").value(admin.id))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun banUserBySuperAdmin() {
+        //given
+        // 메인 관리자로 로그인
+        val cookieMap = login("admin1", "password1")
+
+        // when
+        // user1을 밴함
+        val user = userService.getUserByUsername("user1")
+            .orElseThrow { RuntimeException() }
+
+        val perform = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/admin/users/${user.id}/ban")
+                .content(
+                    """
+				{
+					"reason": "기분이 나빠서"
+				}
+				""".trimIndent()
+                )
+                .contentType("application/json")
+                .characterEncoding("utf-8")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        )
+
+        val id = objectMapper.readTree(perform.andReturn().response.contentAsString)["data"]["banListId"].asText()
+
+        val banList = banListRepository.findById(id).get()
+
+        // then
+        val foundedUser = userService.getUserByUsername("user1")
+
+        perform
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.handler().handlerType(AdminController::class.java))
+            .andExpect(MockMvcResultMatchers.handler().methodName("banUser"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("200-1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("유저 정지 성공"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.banListId").value(banList.id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.reason").value(banList.reason))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(banList.bannedUser.id))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.banCount").value(foundedUser.get().blockedCount))
+        Assertions.assertThat(foundedUser.get().blocked).isTrue()
+        Assertions.assertThat(foundedUser.get().blockedCount).isEqualTo(1)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun deletePostBySuperAdmin() {
+        //given
+        // 메인 관리자로 로그인
+        val cookieMap = login("admin1", "password1")
+
+        //when
+        // id를 가진 post를 삭제
+        val id = productPostService.getPosts(1, 1, "", "asc", 0, 1000000, emptyList())
+            .items[0].id
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/posts/$id")
+                .cookie(cookieMap["accessToken"], cookieMap["refreshToken"])
+        )
+
+        // then
+
+        // 삭제된 product post 조회 시 오류 발생해야 한다.
+        Assertions.assertThatThrownBy { productPostService.getPost(id) }
+            .isInstanceOf(ProductPostNotFoundException::class.java)
+
+        result
+            .andExpect(MockMvcResultMatchers.status().isNoContent)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("204-1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("게시글 삭제 성공."))
+    }
 }

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/user/service/email/service/BouncedMailServiceTest.kt
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/user/service/email/service/BouncedMailServiceTest.kt
@@ -44,7 +44,7 @@ class BouncedMailServiceTest {
         mockMessage = mock(Message::class.java)  // Message 목 객체 생성
         spyService = spy(bouncedEmailService)     // 부분 모킹을 위한 스파이 객체 생성
 
-        doReturn(mockFolder).`when`(spyService).emailFolder // getEmailFolder() 호출 시 가짜 폴더 반환
+        doReturn(mockFolder).`when`(spyService).getEmailFolder() // getEmailFolder() 호출 시 가짜 폴더 반환
         `when`(mockFolder.messages).thenReturn(arrayOf(mockMessage))  // 폴더의 메시지 배열 반환 설정
         doReturn(LocalDateTime.now().minusSeconds(10)).`when`(spyService).getMessageTime(mockMessage)  // getMessageTime() 호출 시 현재 시간에서 10초 전 반환
         `when`(pop3.untilTime).thenReturn(120)  // pop3.getUntilTime() 호출 시 120초 반환

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -30,6 +30,7 @@ export default function ClientLayout({
     removeLoginMember,
     isLoginMemberPending,
     isAdmin,
+    isSuperAdmin,
     setNoLoginMember,
   } = useLoginMember();
 
@@ -45,6 +46,7 @@ export default function ClientLayout({
     isLogin,
     isLoginMemberPending,
     isAdmin,
+    isSuperAdmin,
     setNoLoginMember,
   };
 

--- a/frontend/src/app/_type/AdminListSuperAdminItem.ts
+++ b/frontend/src/app/_type/AdminListSuperAdminItem.ts
@@ -1,0 +1,3 @@
+import { components } from "@/lib/backend/apiV1/schema";
+
+export type AdminListSuperAdminItem = components["schemas"]["UserDto"];

--- a/frontend/src/app/admin/ClientPage.tsx
+++ b/frontend/src/app/admin/ClientPage.tsx
@@ -1,15 +1,24 @@
 "use client";
 
 import { lazy, useEffect, useState } from "react";
-import { Home, User, Settings } from "lucide-react";
+import { Home, User, Settings, Shield } from "lucide-react";
 import { useRouter } from "next/navigation";
 
+// 기존 관리자 페이지들
 const ProductListAdmin = lazy(() => import("./_pages/ProductListAdmin"));
 const NoticeAdmin = lazy(() => import("./_pages/NoticeAdmin"));
 const UserListAdmin = lazy(() => import("./_pages/UserListAdmin"));
 const SystemLog = lazy(() => import("./_pages/SystemLog"));
+const AdminListSuperAdmin = lazy(() => import("./_pages/AdminListSuperAdmin"));
+const AdminSignUp = lazy(() => import("./_pages/AdminSignUp"));
 
-type PageType = "ProductList" | "Notice" | "UserList" | "SystemLog";
+type PageType =
+  | "ProductList"
+  | "Notice"
+  | "UserList"
+  | "SystemLog"
+  | "AdminListSuperAdmin"
+  | "AdminSignUp";
 
 interface SidebarProps {
   setPage: (page: PageType) => void;
@@ -17,7 +26,7 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ setPage }) => {
   return (
-    <div className="w-64 bg-gray-900 text-white p-5 flex flex-col gap-4 ">
+    <div className="w-64 bg-gray-900 text-white p-5 flex flex-col gap-4">
       <button
         onClick={() => setPage("ProductList")}
         className="flex items-center gap-2 p-3 hover:bg-gray-700 rounded"
@@ -42,6 +51,18 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage }) => {
       >
         <Settings size={20} /> 로그
       </button>
+      <button
+        onClick={() => setPage("AdminListSuperAdmin")}
+        className="flex items-center gap-2 p-3 hover:bg-gray-700 rounded"
+      >
+        <Shield size={20} /> 관리자 리스트
+      </button>
+      <button
+        onClick={() => setPage("AdminSignUp")}
+        className="flex items-center gap-2 p-3 hover:bg-gray-700 rounded"
+      >
+        <Shield size={20} /> 관리자 등록
+      </button>
     </div>
   );
 };
@@ -53,10 +74,12 @@ interface ContentProps {
 const Content: React.FC<ContentProps> = ({ page }) => {
   return (
     <div className="flex flex-col flex-1 p-5">
-      {page === "ProductList" && <ProductListAdmin></ProductListAdmin>}
-      {page === "UserList" && <UserListAdmin></UserListAdmin>}
-      {page === "Notice" && <NoticeAdmin></NoticeAdmin>}
-      {page === "SystemLog" && <SystemLog></SystemLog>}
+      {page === "ProductList" && <ProductListAdmin />}
+      {page === "UserList" && <UserListAdmin />}
+      {page === "Notice" && <NoticeAdmin />}
+      {page === "SystemLog" && <SystemLog />}
+      {page === "AdminListSuperAdmin" && <AdminListSuperAdmin />}
+      {page === "AdminSignUp" && <AdminSignUp />}
     </div>
   );
 };
@@ -64,32 +87,28 @@ const Content: React.FC<ContentProps> = ({ page }) => {
 export default function SidebarLayout({
   searchParams,
 }: {
-  searchParams: {
-    tab: string;
-  };
+  searchParams: { tab: string };
 }) {
   const router = useRouter();
   const { tab } = searchParams;
-
   const [currentPage, setCurrentPage] = useState<PageType>(
-    (tab as PageType) || ("ProductList" as PageType)
+    (tab as PageType) || "ProductList"
   );
 
   useEffect(() => {
     if (!tab) {
-      router.replace("?tab=ProductList"); // ✅ 초기 상태 설정
+      router.replace("?tab=ProductList"); // 초기 상태 설정
     }
     setCurrentPage(tab as PageType);
   }, [tab, router]);
-
-  // URL에서 현재 탭 상태 가져오기
 
   // 페이지 변경 시 URL 업데이트
   const setPage = (page: PageType) => {
     router.push(`?tab=${page}`, { scroll: false });
   };
+
   return (
-    <div className="flex flex-1 w-full ">
+    <div className="flex flex-1 w-full">
       <Sidebar setPage={setPage} />
       <Content page={currentPage} />
     </div>

--- a/frontend/src/app/admin/ClientPage.tsx
+++ b/frontend/src/app/admin/ClientPage.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { lazy, useEffect, useState } from "react";
+import { lazy, useEffect, useState, useContext } from "react";
 import { Home, User, Settings, Shield } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { LoginMemberContext } from "@/app/stores/auth/loginMemberStore";
 
 // 기존 관리자 페이지들
 const ProductListAdmin = lazy(() => import("./_pages/ProductListAdmin"));
@@ -25,6 +26,9 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ setPage }) => {
+  // 로그인 정보 가져오기
+  const { isSuperAdmin } = useContext(LoginMemberContext);
+
   return (
     <div className="w-64 bg-gray-900 text-white p-5 flex flex-col gap-4">
       <button
@@ -51,18 +55,22 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage }) => {
       >
         <Settings size={20} /> 로그
       </button>
-      <button
-        onClick={() => setPage("AdminListSuperAdmin")}
-        className="flex items-center gap-2 p-3 hover:bg-gray-700 rounded"
-      >
-        <Shield size={20} /> 관리자 리스트
-      </button>
-      <button
-        onClick={() => setPage("AdminSignUp")}
-        className="flex items-center gap-2 p-3 hover:bg-gray-700 rounded"
-      >
-        <Shield size={20} /> 관리자 등록
-      </button>
+      {isSuperAdmin && (
+        <>
+          <button
+            onClick={() => setPage("AdminListSuperAdmin")}
+            className="flex items-center gap-2 p-3 hover:bg-gray-700 rounded"
+          >
+            <Shield size={20} /> 관리자 리스트
+          </button>
+          <button
+            onClick={() => setPage("AdminSignUp")}
+            className="flex items-center gap-2 p-3 hover:bg-gray-700 rounded"
+          >
+            <Shield size={20} /> 관리자 등록
+          </button>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/app/admin/_components/adminlist/AdminListSuperAdminAccordian.tsx
+++ b/frontend/src/app/admin/_components/adminlist/AdminListSuperAdminAccordian.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import client from "@/lib/client";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+import { AdminListSuperAdminItem } from "@/app/_type/AdminListSuperAdminItem";
+import { useState } from "react";
+
+export default function AdminListSuperAdminAccordian({
+  items,
+}: {
+  items: AdminListSuperAdminItem[];
+}) {
+  const deleteAdmin = async (item: AdminListSuperAdminItem) => {
+    const userConfirmed = window.confirm(
+      "정말로 이 관리자를 삭제하시겠습니까?"
+    );
+    if (!userConfirmed) return;
+
+    // path parameter를 활용하여 DELETE 요청 전달
+    const response = await client.DELETE("/api/admin/{adminId}", {
+      params: {
+        path: {
+          adminId: item.id,
+        },
+      },
+      credentials: "include",
+    });
+
+    if (response.error) {
+      console.error(response.response);
+      alert("관리자 삭제에 실패했습니다.");
+      return;
+    }
+    window.location.reload();
+  };
+
+  return (
+    <div className="w-full mx-auto overflow-y-auto border rounded-lg px-2 flex-1 flex flex-col">
+      <Accordion
+        type="multiple"
+        className="w-full mx-auto mt-5 flex-1 flex flex-col"
+      >
+        {items.map((item) => (
+          <AccordionItem
+            key={item.id}
+            value={String(item.id)}
+            className="border rounded-lg border-gray-300 my-2"
+          >
+            <AccordionTrigger className="w-full flex justify-between px-3 text-xl hover:cursor-pointer py-4">
+              <p>{item.id}</p>
+              <ChevronDown className="ml-2" size={20} />
+            </AccordionTrigger>
+            <AccordionContent className="flex justify-between p-6 min-h-48 bg-gray-300">
+              <div className="flex flex-col space-y-2">
+                <p>아이디: {item.username}</p>
+                <p>닉네임: {item.nickname}</p>
+                <p>이메일: {item.email}</p>
+                <p>권한: {item.role}</p>
+                <p>프로필: {item.profileUrl}</p>
+                <p>생성일: {item.createdAt}</p>
+                <p>수정일: {item.modifiedAt}</p>
+              </div>
+              <div className="flex flex-col items-end justify-center">
+                <Button
+                  variant="destructive"
+                  className="hover:cursor-pointer"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    deleteAdmin(item);
+                  }}
+                >
+                  관리자 삭제
+                </Button>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/_pages/AdminListSuperAdmin.tsx
+++ b/frontend/src/app/admin/_pages/AdminListSuperAdmin.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import PageSizeSelector from "../_components/common/PageSizeSelector";
+import Pagination from "../_components/common/Pagination";
+import AdminListSuperAdminAccordian from "../_components/adminlist/AdminListSuperAdminAccordian";
+import { AdminListSuperAdminItem } from "@/app/_type/AdminListSuperAdminItem";
+import client from "@/lib/client";
+import { Button } from "@/components/ui/button";
+import AdminSignUp from "./AdminSignUp";
+
+export default function AdminListSuperAdmin() {
+  const router = useRouter();
+  const [page, setPage] = useState<number>(0);
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [adminList, setAdminList] = useState<AdminListSuperAdminItem[]>([]);
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [showAdminSignUp, setShowAdminSignUp] = useState(false);
+
+  const getAdmins = async () => {
+    const result = await client.GET("/api/admin/admins", {
+      params: {
+        query: {
+          size: pageSize,
+          page: page,
+          pageable: {},
+        },
+      },
+      credentials: "include",
+    });
+
+    if (result.error) {
+      console.error(result.response);
+      return;
+    }
+
+    setAdminList(result.data!.data.content!);
+    setTotalPages(result.data!.data.totalPages!);
+  };
+
+  useEffect(() => {
+    getAdmins();
+  }, [page, pageSize]);
+
+  // 신규 관리자 등록 버튼 핸들러 (모달 오픈)
+  const handleNewAdmin = () => {
+    setShowAdminSignUp(true);
+  };
+
+  return (
+    <div className="relative w-full flex-1 flex flex-col min-h-0">
+      <div className="flex-1 flex flex-col min-h-0">
+        <div className="flex justify-end items-end">
+          <PageSizeSelector
+            selectedPageSize={pageSize}
+            setSelectedPageSize={setPageSize}
+          />
+        </div>
+        <AdminListSuperAdminAccordian items={adminList} />
+        <Pagination
+          currentPage={page}
+          onPageChange={(newPage) => setPage(newPage)}
+          totalPages={totalPages}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/_pages/AdminSignUp.tsx
+++ b/frontend/src/app/admin/_pages/AdminSignUp.tsx
@@ -117,7 +117,9 @@ export default function AdminSignUp() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       <form onSubmit={join} className="flex flex-col gap-8 w-full max-w-4xl">
-        <h2 className="text-3xl font-bold text-center">관리자 회원가입</h2>
+        <h2 className="text-3xl font-bold text-center">
+          신규 관리자 계정 등록
+        </h2>
         <Input
           type="text"
           name="username"
@@ -220,7 +222,7 @@ export default function AdminSignUp() {
             !isEmailVerified
           }
         >
-          관리자 회원가입
+          신규 관리자 등록
         </Button>
       </form>
     </div>

--- a/frontend/src/app/admin/_pages/AdminSignUp.tsx
+++ b/frontend/src/app/admin/_pages/AdminSignUp.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import client from "@/lib/client";
+import { useRouter } from "next/navigation";
+import { useState, ChangeEvent, FormEvent } from "react";
+
+export default function AdminSignUp() {
+  const router = useRouter();
+  const [formData, setFormData] = useState({
+    username: "",
+    password: "",
+    email: "",
+    nickname: "",
+  });
+
+  const [isEmailSent, setIsEmailSent] = useState(false);
+  const [emailCode, setEmailCode] = useState("");
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [emailStatus, setEmailStatus] = useState("");
+  const [emailStatusColor, setEmailStatusColor] = useState("text-red-500");
+  const [codeStatus, setCodeStatus] = useState("");
+  const [codeStatusColor, setCodeStatusColor] = useState("text-red-500");
+  const [isCodeLoading, setIsCodeLoading] = useState(false);
+
+  function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    setFormData((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  }
+
+  async function sendEmailVerification() {
+    if (!formData.email.trim()) {
+      alert("이메일을 입력해주세요.");
+      return;
+    }
+    setIsLoading(true);
+    setEmailStatus("인증 코드 발송 중입니다. 잠시만 기다려 주세요");
+    setEmailStatusColor("text-red-500");
+    setIsEmailSent(true);
+
+    const response = await client.POST("/api/users/email/code", {
+      body: { email: formData.email },
+    });
+    setIsLoading(false);
+    if (response.error) {
+      alert(response.error.message);
+      setIsEmailSent(false);
+      setEmailStatus("");
+      return;
+    }
+    setEmailStatus("인증 코드가 발송되었습니다.");
+    setEmailStatusColor("text-blue-500");
+  }
+
+  async function verifyEmailCode() {
+    if (!emailCode.trim()) {
+      alert("인증 코드를 입력해주세요.");
+      return;
+    }
+    setIsCodeLoading(true);
+    const response = await client.POST("/api/users/email/code/verify", {
+      body: { email: formData.email, code: emailCode },
+    });
+    setIsCodeLoading(false);
+    if (response.error) {
+      setCodeStatus(response.error.message);
+      setCodeStatusColor("text-red-500");
+      return;
+    }
+    setCodeStatus("이메일 인증이 완료되었습니다.");
+    setCodeStatusColor("text-blue-500");
+    setIsEmailVerified(true);
+  }
+
+  async function join(e: FormEvent) {
+    e.preventDefault();
+
+    if (!formData.username.trim()) {
+      alert("아이디를 입력해주세요.");
+      return;
+    }
+    if (!formData.password.trim()) {
+      alert("비밀번호를 입력해주세요.");
+      return;
+    }
+    if (!formData.email.trim()) {
+      alert("이메일을 입력해주세요.");
+      return;
+    }
+    if (!formData.nickname.trim()) {
+      alert("닉네임을 입력해주세요.");
+      return;
+    }
+    if (!isEmailVerified) {
+      alert("이메일 인증을 완료해주세요.");
+      return;
+    }
+
+    const response = await client.POST("/api/admin/signup", {
+      body: formData,
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (response.error) {
+      alert(response.error.message);
+      return;
+    }
+    alert("관리자 회원가입에 성공하였습니다.");
+    router.push("/admin");
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={join} className="flex flex-col gap-8 w-full max-w-4xl">
+        <h2 className="text-3xl font-bold text-center">관리자 회원가입</h2>
+        <Input
+          type="text"
+          name="username"
+          placeholder="아이디"
+          className="border-2 border-black"
+          value={formData.username}
+          onChange={handleChange}
+          required
+        />
+        <Input
+          type="password"
+          name="password"
+          placeholder="비밀번호"
+          className="border-2 border-black"
+          value={formData.password}
+          onChange={handleChange}
+          required
+        />
+        <div className="flex flex-col gap-1">
+          <div className="flex gap-2 items-center">
+            <Input
+              type="email"
+              name="email"
+              placeholder="이메일"
+              className="border-2 border-black flex-grow"
+              value={formData.email}
+              onChange={handleChange}
+              required
+            />
+            <Button
+              type="button"
+              className="bg-blue-500 text-white p-2 flex items-center justify-center"
+              onClick={sendEmailVerification}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <div className="animate-spin border-2 border-white border-t-transparent w-5 h-5 rounded-full"></div>
+              ) : (
+                "이메일 인증"
+              )}
+            </Button>
+          </div>
+          {emailStatus && (
+            <p className={`text-sm ${emailStatusColor}`}>{emailStatus}</p>
+          )}
+        </div>
+        {isEmailSent && (
+          <div className="flex flex-col gap-1">
+            <div className="flex gap-2 items-center">
+              <Input
+                type="text"
+                placeholder="인증 코드"
+                className="border-2 border-black flex-grow"
+                value={emailCode}
+                onChange={(e) => setEmailCode(e.target.value)}
+              />
+              <Button
+                type="button"
+                className="bg-green-500 text-white p-2 flex items-center justify-center"
+                onClick={verifyEmailCode}
+                disabled={isCodeLoading}
+              >
+                {isCodeLoading ? (
+                  <div className="animate-spin border-2 border-white border-t-transparent w-5 h-5 rounded-full"></div>
+                ) : (
+                  "확인"
+                )}
+              </Button>
+            </div>
+            {codeStatus && (
+              <p className={`text-sm ${codeStatusColor}`}>{codeStatus}</p>
+            )}
+          </div>
+        )}
+        <Input
+          type="text"
+          name="nickname"
+          placeholder="닉네임"
+          className="border-2 border-black"
+          value={formData.nickname}
+          onChange={handleChange}
+          required
+        />
+        <Button
+          type="submit"
+          className={`w-full p-4 ${
+            formData.username &&
+            formData.password &&
+            formData.email &&
+            formData.nickname &&
+            isEmailVerified
+              ? "bg-blue-500 text-white"
+              : "bg-gray-300 text-gray-500 cursor-not-allowed"
+          }`}
+          disabled={
+            !formData.username ||
+            !formData.password ||
+            !formData.email ||
+            !formData.nickname ||
+            !isEmailVerified
+          }
+        >
+          관리자 회원가입
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/stores/auth/loginMemberStore.tsx
+++ b/frontend/src/app/stores/auth/loginMemberStore.tsx
@@ -12,6 +12,7 @@ export const LoginMemberContext = createContext<{
   isLogin: boolean;
   isLoginMemberPending: boolean;
   isAdmin: boolean;
+  isSuperAdmin: boolean;
   setNoLoginMember: () => void;
 }>({
   loginMember: createEmptyMember(),
@@ -20,6 +21,7 @@ export const LoginMemberContext = createContext<{
   isLogin: false,
   isLoginMemberPending: true,
   isAdmin: false,
+  isSuperAdmin: false,
   setNoLoginMember: () => {},
 });
 
@@ -61,8 +63,10 @@ export function useLoginMember() {
   };
 
   const isLogin = loginMember.id !== "";
-  const isAdmin = loginMember.role.toUpperCase() === "ADMIN" 
-  || loginMember.role.toUpperCase() === "SUPER_ADMIN";
+  const isAdmin =
+    loginMember.role.toUpperCase() === "ADMIN" ||
+    loginMember.role.toUpperCase() === "SUPER_ADMIN";
+  const isSuperAdmin = loginMember.role.toUpperCase() === "SUPER_ADMIN";
 
   return {
     loginMember,
@@ -71,6 +75,7 @@ export function useLoginMember() {
     isLoginMemberPending,
     setLoginMember,
     isAdmin,
+    isSuperAdmin,
     setNoLoginMember,
   };
 }

--- a/frontend/src/app/stores/auth/loginMemberStore.tsx
+++ b/frontend/src/app/stores/auth/loginMemberStore.tsx
@@ -61,7 +61,8 @@ export function useLoginMember() {
   };
 
   const isLogin = loginMember.id !== "";
-  const isAdmin = loginMember.role === "ADMIN";
+  const isAdmin = loginMember.role.toUpperCase() === "ADMIN" 
+  || loginMember.role.toUpperCase() === "SUPER_ADMIN";
 
   return {
     loginMember,

--- a/frontend/src/app/user/me/ClientPage.tsx
+++ b/frontend/src/app/user/me/ClientPage.tsx
@@ -13,58 +13,66 @@ export default function ClientPage() {
   return (
     <div className="flex flex-col items-center p-6 w-full">
       <h2 className="text-2xl font-bold mb-4">내 정보 조회</h2>
-      <div className="border p-4 rounded-md w-1/2 shadow-lg">
-        <div className="mb-2">
-          <strong>아이디:</strong> {loginMember.username}
-        </div>
-        <div className="mb-2">
-          <strong>이메일:</strong> {loginMember.email}
-        </div>
-        <div className="mb-2">
-          <strong>닉네임:</strong> {loginMember.nickname}
-        </div>
-        <div className="mb-2">
-          <strong>주소:</strong> {loginMember.address || "주소 없음"}
-        </div>
-        <div className="mb-2">
-          <strong>위치:</strong> { 
-            loginMember.latitude === 0 && loginMember.longitude === 0 
-              ? "정보 없음" 
-              : `위도: ${loginMember.latitude} / 경도: ${loginMember.longitude}`
-          }
-        </div>
-        <div className="mb-4">
-          <strong>프로필 사진:</strong> <br />
+
+      <div className="flex flex-col md:flex-row border p-6 rounded-md w-full max-w-xl shadow-lg">
+        {/* 왼쪽: 프로필 사진 (정사각형, 크게) */}
+        <div className="flex-shrink-0 flex items-center justify-center mb-4 md:mb-0 md:mr-6">
           {loginMember.profileUrl ? (
             <img
               src={loginMember.profileUrl}
               alt="프로필"
-              className="w-24 h-24 rounded-full mt-2"
+              className="w-80 h-80 object-cover border"
             />
           ) : (
-            <span>없음</span>
+            <div className="w-80 h-80 flex items-center justify-center border bg-gray-100">
+              <span>없음</span>
+            </div>
           )}
         </div>
-        <Button
-          onClick={() => router.push("/user/me/modify")}
-          className="w-full bg-blue-500 text-white"
-        >
-          내 정보 수정
-        </Button>
+
+        {/* 오른쪽: 회원 정보 */}
+        <div className="flex flex-col justify-center">
+          <div className="mb-2">
+            <strong>아이디:</strong> {loginMember.username}
+          </div>
+          <div className="mb-2">
+            <strong>이메일:</strong> {loginMember.email}
+          </div>
+          <div className="mb-2">
+            <strong>닉네임:</strong> {loginMember.nickname}
+          </div>
+          <div className="mb-2">
+            <strong>주소:</strong> {loginMember.address || "주소 없음"}
+          </div>
+          <div className="mb-2">
+            <strong>위치:</strong>{" "}
+            {loginMember.latitude === 0 && loginMember.longitude === 0
+              ? "정보 없음"
+              : `위도: ${loginMember.latitude} / 경도: ${loginMember.longitude}`}
+          </div>
+          <Button
+            onClick={() => router.push("/user/me/modify")}
+            className="w-full md:w-auto bg-blue-500 text-white mt-4"
+          >
+            내 정보 수정
+          </Button>
+        </div>
       </div>
 
-      {/* 위도, 경도가 0이 아닐 경우 지도 표시 */}
+      {/* 지도 영역 */}
       {(loginMember.latitude !== 0 || loginMember.longitude !== 0) && (
-        <div className="mt-4 w-1/2" style={{ height: "350px" }}> {/* 지도의 높이 설정 */}
+        <div className="mt-4 w-full max-w-xl" style={{ height: "350px" }}>
           <h1 className="text-lg mb-2">Map</h1>
           <MapComponent
-            currentPos={{ lat: loginMember.latitude, lng: loginMember.longitude, zoom: 18 }}
-            onLocationSelect={() => {}} // 사용자가 클릭해도 상태 변경 없도록 빈 함수
+            currentPos={{
+              lat: loginMember.latitude,
+              lng: loginMember.longitude,
+              zoom: 18,
+            }}
+            onLocationSelect={() => {}}
           />
         </div>
       )}
-
-      
     </div>
   );
 }

--- a/frontend/src/app/user/me/ClientPage.tsx
+++ b/frontend/src/app/user/me/ClientPage.tsx
@@ -14,7 +14,8 @@ export default function ClientPage() {
     <div className="flex flex-col items-center p-6 w-full">
       <h2 className="text-2xl font-bold mb-4">내 정보 조회</h2>
 
-      <div className="flex flex-col md:flex-row border p-6 rounded-md w-full max-w-xl shadow-lg">
+      {/* 회원 정보 영역의 최대 너비를 늘려 넉넉하게 표시 */}
+      <div className="flex flex-col md:flex-row border p-6 rounded-md w-full max-w-5xl shadow-lg">
         {/* 왼쪽: 프로필 사진 (정사각형, 크게) */}
         <div className="flex-shrink-0 flex items-center justify-center mb-4 md:mb-0 md:mr-6">
           {loginMember.profileUrl ? (
@@ -30,8 +31,8 @@ export default function ClientPage() {
           )}
         </div>
 
-        {/* 오른쪽: 회원 정보 */}
-        <div className="flex flex-col justify-center">
+        {/* 오른쪽: 회원 정보 영역 (flex-grow 추가로 공간 활용) */}
+        <div className="flex flex-col justify-center flex-grow">
           <div className="mb-2">
             <strong>아이디:</strong> {loginMember.username}
           </div>
@@ -61,7 +62,7 @@ export default function ClientPage() {
 
       {/* 지도 영역 */}
       {(loginMember.latitude !== 0 || loginMember.longitude !== 0) && (
-        <div className="mt-4 w-full max-w-xl" style={{ height: "350px" }}>
+        <div className="mt-4 w-full max-w-5xl" style={{ height: "350px" }}>
           <h1 className="text-lg mb-2">Map</h1>
           <MapComponent
             currentPos={{

--- a/frontend/src/app/user/me/modify/ClientPage.tsx
+++ b/frontend/src/app/user/me/modify/ClientPage.tsx
@@ -4,6 +4,7 @@ import { LoginMemberContext } from "@/app/stores/auth/loginMemberStore";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import client from "@/lib/client";
+import fileUploadClient from "@/lib/fileUploadClient";
 import { useRouter } from "next/navigation";
 import { useState, useContext, useEffect } from "react";
 import MapComponent from "@/components/MapComponent";
@@ -22,6 +23,9 @@ export default function ClientPage() {
   const [emailStatusColor, setEmailStatusColor] = useState("text-red-500");
   const [codeStatus, setCodeStatus] = useState("");
   const [codeStatusColor, setCodeStatusColor] = useState("text-red-500");
+  const [selectedProfileFile, setSelectedProfileFile] = useState<File | null>(
+    null
+  );
 
   // 위치 관리
   const [latitude, setLatitude] = useState(0);
@@ -42,18 +46,20 @@ export default function ClientPage() {
         setLongitude(position.coords.longitude);
       });
     };
-    
+
     getCurrentPosition();
   }, [loginMember]);
 
-  const fetchAddressFromCoordinates = async (lat:any, lng:any) => {
-    if(lat==0 || lng==0){
-      return "주소를 입력해주세요" ;
+  const fetchAddressFromCoordinates = async (lat: number, lng: number) => {
+    if (lat === 0 || lng === 0) {
+      return "주소를 입력해주세요";
     }
     try {
-      const response = await fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`);
+      const response = await fetch(
+        `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`
+      );
       const data = await response.json();
-      
+
       if (data && data.display_name) {
         setAddress(data.display_name); // 주소를 상태에 저장
         return data.display_name;
@@ -68,52 +74,52 @@ export default function ClientPage() {
     }
   };
 
-  const registerLocation = async (lat:any, lng:any) => {
-    // if (lat === 0 && lng === 0) {
-    //     alert("위치 정보를 가져오지 못했습니다.");
-    //     return;
-    // }
-
+  const registerLocation = async (lat: number, lng: number) => {
     try {
       const response = await client.PUT("/api/users/me/location", {
         body: { latitude: lat, longitude: lng },
         credentials: "include",
       });
-      
+
       if (response.error) {
         setLocationStatus("위치 등록에 실패했습니다.");
         return;
       }
-      
+
       const user = response.data.data; // 서버에서 받은 사용자 정보
-      setLatitude(user.latitude);  // 서버에서 받은 위도
-      setLongitude(user.longitude); // 서버에서 받은 경도
+      setLatitude(user.latitude);
+      setLongitude(user.longitude);
       setLocationStatus("위치가 성공적으로 등록되었습니다.");
-      const new_address = await fetchAddressFromCoordinates(user.latitude, user.longitude); // 주소 패치
+      const new_address = await fetchAddressFromCoordinates(
+        user.latitude,
+        user.longitude
+      );
       setMapVisible(false); // 위치 등록 후 지도 닫기
 
-      const updateUserResponse = await client.PUT("/api/users/me", {
+      await client.PUT("/api/users/me", {
         body: {
-          emial: loginMember.email,
+          email: loginMember.email,
           nickname: loginMember.nickname,
-          address: new_address, // 위도 경도로 얻은 새 주소
+          address: new_address,
           profileUrl: loginMember.profileUrl,
         },
         credentials: "include",
       });
-      console.log("새로얻은 주소: ",new_address);
-
+      console.log("새로얻은 주소: ", new_address);
     } catch (error) {
-        console.error("위치 등록 중 오류 발생:", error);
-        setLocationStatus("위치 등록에 실패했습니다.");
+      console.error("위치 등록 중 오류 발생:", error);
+      setLocationStatus("위치 등록에 실패했습니다.");
     }
   };
 
-
-  
   function handleEmailChange(e: React.ChangeEvent<HTMLInputElement>) {
     const newEmail = e.target.value;
     setEmail(newEmail);
+
+    // 이메일을 수정할 때 지도 창이 열려있다면 닫기
+    if (mapVisible) {
+      setMapVisible(false);
+    }
 
     if (newEmail === loginMember.email) {
       // 기존 이메일로 돌아가면 인증 필요 없음
@@ -175,7 +181,28 @@ export default function ClientPage() {
     setCodeStatus("이메일 인증이 완료되었습니다.");
     setCodeStatusColor("text-blue-500");
     setIsEmailVerified(true);
+
+    // 인증 코드를 입력할 때 지도 창이 열려 있다면 닫기
+    if (mapVisible) {
+      setMapVisible(false);
+    }
   }
+
+  // 파일 업로드 함수
+  const uploadFile = async (file: File): Promise<string> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await fileUploadClient.POST("/api/uploadFile", {
+      body: formData as any,
+      rawBody: true,
+      credentials: "include",
+      headers: {},
+    });
+    if (response.error) {
+      console.error("파일 업로드 실패", response.error);
+    }
+    return response.data as string;
+  };
 
   async function updateInfo(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -185,86 +212,118 @@ export default function ClientPage() {
       return;
     }
 
-    const formData = e.target as HTMLFormElement;
-    console.log(formData);
-    const email = formData.email.value;
-    const nickname = formData.nickname.value;
+    const form = e.target as HTMLFormElement;
+    const emailVal = form.email.value;
+    const nickname = form.nickname.value;
     const _address = address || loginMember.address;
-    const profileUrl = formData.profileUrl.value;
-
+    let profileUrl = loginMember.profileUrl;
+    if (selectedProfileFile) {
+      try {
+        profileUrl = await uploadFile(selectedProfileFile);
+      } catch (error: any) {
+        alert("파일 업로드 중 오류가 발생했습니다: " + error.message);
+        return;
+      }
+    }
     const response = await client.PUT("/api/users/me", {
       body: {
-        email,
+        email: emailVal,
         nickname,
-        address:_address,
+        address: _address,
         profileUrl,
       },
       credentials: "include",
     });
-
     if (response.error) {
       alert(response.error.message);
       router.push("/user/login");
       return;
     }
-
-    console.log("서버에 전송하는 주소: ",_address);
+    console.log("서버에 전송하는 주소: ", _address);
     alert("사용자 정보가 성공적으로 수정되었습니다.");
     setLoginMember(response.data.data);
     router.push("/user/me");
   }
 
+  function handleProfileFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (e.target.files && e.target.files.length > 0) {
+      setSelectedProfileFile(e.target.files[0]);
+    }
+  }
+
   return (
-    <>
-      <div className="flex h-full w-full justify-center">
-        <div className="flex flex-col gap-2">
-          <h2 className="text-xl font-bold text-center">회원 정보 수정</h2>
-
-          <Button onClick={() => {
-              setMapVisible(true); // 지도를 표시
-          }} className="mt-4">
-              위치 등록
-          </Button>
-
-
-          {mapVisible && (
-              <MapComponent
-                  currentPos={{ lat: latitude, lng: longitude, zoom }}
-                  onLocationSelect={(lat, lng) => {
-                      setLatitude(lat);
-                      setLongitude(lng);
-                      registerLocation(lat, lng); // 핀 클릭 시 위치 등록
-                  }}
+    <div className="flex h-full w-full justify-center p-6">
+      <div className="flex flex-col gap-4 w-full max-w-3xl">
+        <h2 className="text-xl font-bold text-center">회원 정보 수정</h2>
+        <Button onClick={() => setMapVisible(true)} className="mt-4">
+          위치 등록
+        </Button>
+        {mapVisible && (
+          // 지도 영역을 고정된 높이로 감싸서 다른 입력 UI에 영향을 받지 않도록 함.
+          <div style={{ height: "400px", width: "100%" }}>
+            <MapComponent
+              currentPos={{ lat: latitude, lng: longitude, zoom }}
+              onLocationSelect={(lat, lng) => {
+                setLatitude(lat);
+                setLongitude(lng);
+                registerLocation(lat, lng);
+              }}
+            />
+          </div>
+        )}
+        {locationStatus && <h2>{locationStatus}</h2>}
+        {latitude === 0 && longitude === 0 && (
+          <h3 className="text-lg">위치를 등록해 주세요</h3>
+        )}
+        {latitude !== 0 && longitude !== 0 && (
+          <div className="mt-4">
+            <h3 className="text-lg">위치:</h3>
+            <p>위도: {latitude}</p>
+            <p>경도: {longitude}</p>
+            {address && <p>주소: {address}</p>}
+          </div>
+        )}
+        {/* 두 컬럼 레이아웃: 왼쪽은 프로필 사진 영역, 오른쪽은 나머지 입력 필드 */}
+        <form onSubmit={updateInfo} className="flex flex-col md:flex-row gap-4">
+          {/* 왼쪽 컬럼: 프로필 사진 및 사진 변경 버튼 */}
+          <div className="flex flex-col items-center md:w-1/3">
+            <img
+              src={
+                selectedProfileFile
+                  ? URL.createObjectURL(selectedProfileFile)
+                  : loginMember.profileUrl
+              }
+              alt="프로필 사진 미리보기"
+              className="w-32 h-32 object-cover border rounded"
+            />
+            <div className="mt-2">
+              <input
+                id="profileFile"
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleProfileFileChange}
               />
-          )}
-
-          {locationStatus && <h2>{locationStatus}</h2>}
-          
-          {latitude == 0 && longitude == 0 && (
-            <h3 className="text-lg">위치를 등록해 주세요</h3>
-          )}
-            
-          {latitude !== 0 && longitude !== 0 && (
-            <div className="mt-4">
-              <h3 className="text-lg">위치:</h3>
-              <p>위도: {latitude}</p>
-              <p>경도: {longitude}</p>
-              {address && <p>주소: {address}</p>} {/* 주소 표시 */}
+              <label
+                htmlFor="profileFile"
+                className="cursor-pointer inline-block px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded"
+              >
+                사진 변경
+              </label>
             </div>
-          )}
-
-
-          <form onSubmit={updateInfo} className="flex flex-col gap-2">
+          </div>
+          {/* 오른쪽 컬럼: 나머지 입력 필드 */}
+          <div className="flex flex-col gap-4 md:w-2/3">
             <div className="flex flex-col gap-1">
               <label
                 htmlFor="email"
                 className="block text-sm font-medium text-gray-700"
               >
-                {" "}
                 이메일:
               </label>
               <div className="flex gap-2 items-center">
                 <Input
+                  id="email"
                   type="email"
                   name="email"
                   placeholder="이메일"
@@ -300,9 +359,14 @@ export default function ClientPage() {
                 <Input
                   type="text"
                   placeholder="인증 코드"
-                  className="border-2 border-black flex-grow"
+                  className="border-2 border-black flex-grow p-2 text-base"
                   value={emailCode}
-                  onChange={(e) => setEmailCode(e.target.value)}
+                  onChange={(e) => {
+                    if (mapVisible) {
+                      setMapVisible(false);
+                    }
+                    setEmailCode(e.target.value);
+                  }}
                 />
                 <Button
                   type="button"
@@ -322,62 +386,28 @@ export default function ClientPage() {
                 htmlFor="nickname"
                 className="block text-sm font-medium text-gray-700"
               >
-                {" "}
                 닉네임:
               </label>
               <Input
+                id="nickname"
                 type="text"
                 name="nickname"
                 placeholder="닉네임"
                 className="border-2 border-black"
                 defaultValue={loginMember.nickname}
-              />
-            </div>
-            {/* <div>
-              <label
-                htmlFor="address"
-                className="block text-sm font-medium text-gray-700"
-              >
-                주소:
-              </label>
-              <Input
-                type="text"
-                name="address"
-                placeholder="주소"
-                className="border-2 border-black w-[500px]"
-                defaultValue={loginMember.address}
-              />
-            </div> */}
-            <div>
-              <label
-                htmlFor="profileUrl"
-                className="block text-sm font-medium text-gray-700"
-              >
-                프로필URL:
-              </label>
-              <Input
-                type="url"
-                name="profileUrl"
-                placeholder="프로필URL"
-                className="border-2 border-black w-[500px]"
-                defaultValue={loginMember.profileUrl}
+                required
               />
             </div>
 
             <Button
               type="submit"
-              className={`p-2 mt-4 ${
-                isEmailVerified
-                  ? "bg-blue-500 text-white"
-                  : "bg-gray-300 text-gray-500 cursor-not-allowed"
-              }`}
-              disabled={!isEmailVerified}
+              className="w-full bg-blue-500 text-white py-3"
             >
               수정
             </Button>
-          </form>
-        </div>
+          </div>
+        </form>
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/src/app/user/signup/ClientPage.tsx
+++ b/frontend/src/app/user/signup/ClientPage.tsx
@@ -3,8 +3,9 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import client from "@/lib/client";
+import fileUploadClient from "@/lib/fileUploadClient";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, ChangeEvent, FormEvent } from "react";
 
 export default function ClientPage() {
   const router = useRouter();
@@ -14,8 +15,11 @@ export default function ClientPage() {
     email: "",
     nickname: "",
     address: "",
-    profileUrl: "",
+    profileUrl: "", // 업로드 후 반환받은 프로필 이미지 URL
   });
+
+  // 단일 프로필 파일 상태
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [emailCode, setEmailCode] = useState("");
@@ -23,16 +27,25 @@ export default function ClientPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [emailStatus, setEmailStatus] = useState("");
   const [emailStatusColor, setEmailStatusColor] = useState("text-red-500");
-
   const [codeStatus, setCodeStatus] = useState("");
   const [codeStatusColor, setCodeStatusColor] = useState("text-red-500");
-  const [isCodeLoading, setIsCodeLoading] = useState(false); // 로딩 상태
+  const [isCodeLoading, setIsCodeLoading] = useState(false);
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setFormData({
-      ...formData,
+  // 기본 이미지 URL (파일 선택 없을 경우)
+  const defaultImageUrl = "http://localhost:8080/images/default_profile.jpg";
+
+  function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    setFormData((prev) => ({
+      ...prev,
       [e.target.name]: e.target.value,
-    });
+    }));
+  }
+
+  // 파일 입력 핸들러: 선택한 파일을 저장
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    if (e.target.files && e.target.files.length > 0) {
+      setSelectedFile(e.target.files[0]);
+    }
   }
 
   async function sendEmailVerification() {
@@ -40,26 +53,20 @@ export default function ClientPage() {
       alert("이메일을 입력해주세요.");
       return;
     }
-
-    setIsLoading(true); // 로딩중 표시
+    setIsLoading(true);
     setEmailStatus("인증 코드 발송 중입니다. 잠시만 기다려 주세요");
     setEmailStatusColor("text-red-500");
-    setIsEmailSent(true); // 인증 코드 입력칸 생성
-
+    setIsEmailSent(true);
     const response = await client.POST("/api/users/email/code", {
       body: { email: formData.email },
     });
-
-    setIsLoading(false); // 로딩 종료
-
+    setIsLoading(false);
     if (response.error) {
       alert(response.error.message);
       setIsEmailSent(false);
       setEmailStatus("");
       return;
     }
-
-    // 성공 시 메시지 업데이트
     setEmailStatus("인증 코드가 발송되었습니다.");
     setEmailStatusColor("text-blue-500");
   }
@@ -69,24 +76,36 @@ export default function ClientPage() {
       alert("인증 코드를 입력해주세요.");
       return;
     }
-
     const response = await client.POST("/api/users/email/code/verify", {
       body: { email: formData.email, code: emailCode },
     });
-
     if (response.error) {
       setCodeStatus(response.error.message);
-      setCodeStatusColor("text-red-500"); // 에러 메시지는 빨간색
+      setCodeStatusColor("text-red-500");
       return;
     }
-
-    // 성공 시 상태 업데이트
     setCodeStatus("이메일 인증이 완료되었습니다.");
     setCodeStatusColor("text-blue-500");
     setIsEmailVerified(true);
   }
 
-  async function join(e: React.FormEvent) {
+  // AWS S3 파일 업로드 함수
+  const uploadFile = async (file: File): Promise<string> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await fileUploadClient.POST("/api/uploadFile", {
+      body: formData as any,
+      rawBody: true,
+      credentials: "include",
+      headers: {},
+    });
+    if (response.error) {
+      console.error("파일 업로드 실패", response.error);
+    }
+    return response.data as string;
+  };
+
+  async function join(e: FormEvent) {
     e.preventDefault();
 
     if (!formData.username.trim()) {
@@ -106,26 +125,77 @@ export default function ClientPage() {
       return;
     }
 
-    const response = await client.POST("/api/users/signup", {
-      body: formData,
-      credentials: "include",
-    });
+    try {
+      let profileUrl = formData.profileUrl;
+      // 파일이 선택된 경우 업로드 진행 후 URL 사용
+      if (selectedFile) {
+        profileUrl = await uploadFile(selectedFile);
+      } else {
+        // 파일 선택 없을 경우 기본 이미지 사용
+        profileUrl = defaultImageUrl;
+      }
 
-    if (response.error) {
-      alert(response.error.message);
-      return;
+      const joinData = {
+        ...formData,
+        profileUrl,
+      };
+
+      const response = await client.POST("/api/users/signup", {
+        body: joinData,
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (response.error) {
+        alert(response.error.message);
+        return;
+      }
+      alert("회원가입에 성공하였습니다.");
+      router.push("/user/login");
+    } catch (error: any) {
+      alert("파일 업로드 중 오류가 발생했습니다: " + error.message);
     }
-
-    alert("회원가입에 성공하였습니다.");
-    router!.push("/user/login");
   }
 
   return (
-    <>
-      <div className="flex items-center justify-center h-full">
-        <div className="flex flex-col gap-2">
-          <h2 className="text-xl font-bold text-center">회원가입</h2>
-          <form onSubmit={join} className="flex flex-col w-[350px] gap-2">
+    <div className="flex items-center justify-center min-h-screen">
+      {/* 전체 폼 영역 */}
+      <form onSubmit={join} className="flex flex-col gap-8 w-full max-w-4xl">
+        {/* 상단 헤딩 */}
+        <h2 className="text-3xl font-bold text-center">회원가입</h2>
+        {/* 중간 영역: 이미지 미리보기 및 입력창 */}
+        <div className="flex flex-col md:flex-row gap-8">
+          {/* 왼쪽: 프로필 이미지 및 파일 선택 */}
+          <div className="flex flex-col items-center">
+            <img
+              src={
+                selectedFile
+                  ? URL.createObjectURL(selectedFile)
+                  : defaultImageUrl
+              }
+              alt="프로필 미리보기"
+              className="w-48 h-48 object-cover rounded border mb-4"
+            />
+            <div className="relative">
+              <input
+                id="file-upload"
+                type="file"
+                className="hidden"
+                accept="image/*"
+                onChange={handleFileChange}
+              />
+              <label
+                htmlFor="file-upload"
+                className="cursor-pointer inline-block px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded"
+              >
+                프로필 사진 추가
+              </label>
+            </div>
+          </div>
+          {/* 오른쪽: 입력 폼 */}
+          <div className="flex flex-col gap-4 flex-grow">
             <Input
               type="text"
               name="username"
@@ -159,7 +229,7 @@ export default function ClientPage() {
                   type="button"
                   className="bg-blue-500 text-white p-2 flex items-center justify-center"
                   onClick={sendEmailVerification}
-                  disabled={isLoading} // 로딩 중 비활성화
+                  disabled={isLoading}
                 >
                   {isLoading ? (
                     <div className="animate-spin border-2 border-white border-t-transparent w-5 h-5 rounded-full"></div>
@@ -168,7 +238,6 @@ export default function ClientPage() {
                   )}
                 </Button>
               </div>
-
               {emailStatus && (
                 <p className={`text-sm ${emailStatusColor}`}>{emailStatus}</p>
               )}
@@ -187,7 +256,7 @@ export default function ClientPage() {
                     type="button"
                     className="bg-green-500 text-white p-2 flex items-center justify-center"
                     onClick={verifyEmailCode}
-                    disabled={isCodeLoading} // 로딩 중 비활성화
+                    disabled={isCodeLoading}
                   >
                     {isCodeLoading ? (
                       <div className="animate-spin border-2 border-white border-t-transparent w-5 h-5 rounded-full"></div>
@@ -196,8 +265,6 @@ export default function ClientPage() {
                     )}
                   </Button>
                 </div>
-
-                {/* 인증 코드 상태 메시지 */}
                 {codeStatus && (
                   <p className={`text-sm ${codeStatusColor}`}>{codeStatus}</p>
                 )}
@@ -216,42 +283,35 @@ export default function ClientPage() {
               type="text"
               name="address"
               placeholder="주소"
-              className="border-2 border-black w-[500px]"
+              className="border-2 border-black"
               value={formData.address}
               onChange={handleChange}
             />
-            <Input
-              type="url"
-              name="profileUrl"
-              placeholder="프로필URL"
-              className="border-2 border-black w-[500px]"
-              value={formData.profileUrl}
-              onChange={handleChange}
-            />
-            <Button
-              type="submit"
-              className={`p-2 ${
-                formData.username &&
-                formData.password &&
-                formData.email &&
-                formData.nickname &&
-                isEmailVerified
-                  ? "bg-blue-500 text-white"
-                  : "bg-gray-300 text-gray-500 cursor-not-allowed"
-              }`}
-              disabled={
-                !formData.username ||
-                !formData.password ||
-                !formData.email ||
-                !formData.nickname ||
-                !isEmailVerified
-              }
-            >
-              회원가입
-            </Button>
-          </form>
+          </div>
         </div>
-      </div>
-    </>
+        {/* 하단: 회원가입 버튼 (전체 폭) */}
+        <Button
+          type="submit"
+          className={`w-full p-4 ${
+            formData.username &&
+            formData.password &&
+            formData.email &&
+            formData.nickname &&
+            isEmailVerified
+              ? "bg-blue-500 text-white"
+              : "bg-gray-300 text-gray-500 cursor-not-allowed"
+          }`}
+          disabled={
+            !formData.username ||
+            !formData.password ||
+            !formData.email ||
+            !formData.nickname ||
+            !isEmailVerified
+          }
+        >
+          회원가입
+        </Button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -804,6 +804,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/admins": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 관리자 리스트 조회
+         * @description 등록된 관리자 리스트를 조회합니다.
+         */
+        get: operations["getAdminList"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/{adminId}": {
         parameters: {
             query?: never;
@@ -2975,6 +2995,37 @@ export interface operations {
                 };
                 content: {
                     "application/json;charset=UTF-8": components["schemas"]["RsDataListNoticeResBody"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    getAdminList: {
+        parameters: {
+            query: {
+                pageable: components["schemas"]["Pageable"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 관리자 리스트 조회 성공 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataPageUserDto"];
                 };
             };
             /** @description Internal Server Error */

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -424,6 +424,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/signup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 관리자 회원가입
+         * @description superadmin 권한으로 새로운 admin 계정을 생성합니다.
+         */
+        post: operations["signUpAdmin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/notices": {
         parameters: {
             query?: never;
@@ -832,7 +852,7 @@ export interface components {
             address: string;
             profileUrl: string;
             /** @enum {string} */
-            role: "ADMIN" | "USER";
+            role: "SUPER_ADMIN" | "ADMIN" | "USER";
             /** Format: int32 */
             cash: number;
             /** Format: date-time */
@@ -921,7 +941,7 @@ export interface components {
             id: string;
             nickname: string;
             /** @enum {string} */
-            role: "ADMIN" | "USER";
+            role: "SUPER_ADMIN" | "ADMIN" | "USER";
         };
         NoticeResBody: {
             id: string;
@@ -1072,6 +1092,12 @@ export interface components {
             message: string;
             data: components["schemas"]["BanResBody"];
         };
+        SignUpAdminReqBody: {
+            username: string;
+            password: string;
+            nickname: string;
+            email: string;
+        };
         /** @description 공지사항 등록 body */
         NoticeReqBody: {
             title: string;
@@ -1155,8 +1181,8 @@ export interface components {
         };
         SortObject: {
             empty?: boolean;
-            sorted?: boolean;
             unsorted?: boolean;
+            sorted?: boolean;
         };
         RsDataListPreviewPostResponse: {
             code: string;
@@ -1251,10 +1277,10 @@ export interface components {
             data: components["schemas"]["Category"][];
         };
         PageUserDto: {
-            /** Format: int32 */
-            totalPages?: number;
             /** Format: int64 */
             totalElements?: number;
+            /** Format: int32 */
+            totalPages?: number;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["UserDto"][];
@@ -1274,10 +1300,10 @@ export interface components {
             data: components["schemas"]["PageUserDto"];
         };
         PageNoticeResBody: {
-            /** Format: int32 */
-            totalPages?: number;
             /** Format: int64 */
             totalElements?: number;
+            /** Format: int32 */
+            totalPages?: number;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["NoticeResBody"][];
@@ -2259,6 +2285,39 @@ export interface operations {
                 };
                 content: {
                     "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    signUpAdmin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignUpAdminReqBody"];
+            };
+        };
+        responses: {
+            /** @description 관리자 회원가입 성공 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataUserDto"];
                 };
             };
             /** @description Internal Server Error */

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -1030,8 +1030,10 @@ export interface components {
         ChatRoom: {
             sender: string;
             receiver: string;
+            postId?: string;
             id: string;
             roomId: string;
+            writer?: string;
             name: string;
             client: string;
             /** Format: int64 */
@@ -1153,8 +1155,8 @@ export interface components {
         };
         SortObject: {
             empty?: boolean;
-            unsorted?: boolean;
             sorted?: boolean;
+            unsorted?: boolean;
         };
         RsDataListPreviewPostResponse: {
             code: string;
@@ -1197,12 +1199,14 @@ export interface components {
         ChatRoomDto: {
             id: string;
             roomId: string;
+            postId?: string;
+            writer?: string;
             name: string;
             /** Format: int64 */
             userCount: number;
             lastMessage: string;
             /** @enum {string} */
-            messageType: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION";
+            messageType: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION" | "STATUS";
             lastTimestamp: string;
             other: string;
         };
@@ -1229,7 +1233,7 @@ export interface components {
             lastMessage: string;
             lastTimestamp: string;
             /** @enum {string} */
-            type: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION";
+            type: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION" | "STATUS";
         };
         RsDataListMessageDto: {
             code: string;
@@ -1247,10 +1251,10 @@ export interface components {
             data: components["schemas"]["Category"][];
         };
         PageUserDto: {
-            /** Format: int64 */
-            totalElements?: number;
             /** Format: int32 */
             totalPages?: number;
+            /** Format: int64 */
+            totalElements?: number;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["UserDto"][];
@@ -1270,10 +1274,10 @@ export interface components {
             data: components["schemas"]["PageUserDto"];
         };
         PageNoticeResBody: {
-            /** Format: int64 */
-            totalElements?: number;
             /** Format: int32 */
             totalPages?: number;
+            /** Format: int64 */
+            totalElements?: number;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["NoticeResBody"][];

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -804,6 +804,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/{adminId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * 관리자 삭제
+         * @description superadmin 권한으로 특정 admin 계정을 삭제합니다.
+         */
+        delete: operations["deleteAdmin"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/posts/{post-id}": {
         parameters: {
             query?: never;
@@ -2955,6 +2975,37 @@ export interface operations {
                 };
                 content: {
                     "application/json;charset=UTF-8": components["schemas"]["RsDataListNoticeResBody"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    deleteAdmin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                adminId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 관리자 삭제 성공 */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
                 };
             };
             /** @description Internal Server Error */

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -1317,10 +1317,10 @@ export interface components {
             data: components["schemas"]["Category"][];
         };
         PageUserDto: {
-            /** Format: int64 */
-            totalElements?: number;
             /** Format: int32 */
             totalPages?: number;
+            /** Format: int64 */
+            totalElements?: number;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["UserDto"][];
@@ -1340,10 +1340,10 @@ export interface components {
             data: components["schemas"]["PageUserDto"];
         };
         PageNoticeResBody: {
-            /** Format: int64 */
-            totalElements?: number;
             /** Format: int32 */
             totalPages?: number;
+            /** Format: int64 */
+            totalElements?: number;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["NoticeResBody"][];

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -1153,8 +1153,8 @@ export interface components {
         };
         SortObject: {
             empty?: boolean;
-            sorted?: boolean;
             unsorted?: boolean;
+            sorted?: boolean;
         };
         RsDataListPreviewPostResponse: {
             code: string;

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -1030,10 +1030,8 @@ export interface components {
         ChatRoom: {
             sender: string;
             receiver: string;
-            postId?: string;
             id: string;
             roomId: string;
-            writer?: string;
             name: string;
             client: string;
             /** Format: int64 */
@@ -1129,8 +1127,6 @@ export interface components {
             sort?: components["schemas"]["SortObject"];
             /** Format: int32 */
             pageSize?: number;
-            /** Format: int32 */
-            pageNumber?: number;
             paged?: boolean;
             /** Format: int32 */
             pageNumber?: number;
@@ -1142,17 +1138,17 @@ export interface components {
             data: components["schemas"]["SliceCommentDto"];
         };
         SliceCommentDto: {
-            first?: boolean;
-            last?: boolean;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["CommentDto"][];
             /** Format: int32 */
             number?: number;
             sort?: components["schemas"]["SortObject"];
-            pageable?: components["schemas"]["PageableObject"];
+            first?: boolean;
+            last?: boolean;
             /** Format: int32 */
             numberOfElements?: number;
+            pageable?: components["schemas"]["PageableObject"];
             empty?: boolean;
         };
         SortObject: {
@@ -1201,14 +1197,12 @@ export interface components {
         ChatRoomDto: {
             id: string;
             roomId: string;
-            postId?: string;
-            writer?: string;
             name: string;
             /** Format: int64 */
             userCount: number;
             lastMessage: string;
             /** @enum {string} */
-            messageType: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION" | "STATUS";
+            messageType: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION";
             lastTimestamp: string;
             other: string;
         };
@@ -1235,7 +1229,7 @@ export interface components {
             lastMessage: string;
             lastTimestamp: string;
             /** @enum {string} */
-            type: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION" | "STATUS";
+            type: "ENTER" | "QUIT" | "TALK" | "IMAGE" | "LOCATION";
         };
         RsDataListMessageDto: {
             code: string;
@@ -1257,17 +1251,17 @@ export interface components {
             totalElements?: number;
             /** Format: int32 */
             totalPages?: number;
-            first?: boolean;
-            last?: boolean;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["UserDto"][];
             /** Format: int32 */
             number?: number;
             sort?: components["schemas"]["SortObject"];
-            pageable?: components["schemas"]["PageableObject"];
+            first?: boolean;
+            last?: boolean;
             /** Format: int32 */
             numberOfElements?: number;
+            pageable?: components["schemas"]["PageableObject"];
             empty?: boolean;
         };
         RsDataPageUserDto: {
@@ -1280,17 +1274,17 @@ export interface components {
             totalElements?: number;
             /** Format: int32 */
             totalPages?: number;
-            first?: boolean;
-            last?: boolean;
             /** Format: int32 */
             size?: number;
             content?: components["schemas"]["NoticeResBody"][];
             /** Format: int32 */
             number?: number;
             sort?: components["schemas"]["SortObject"];
-            pageable?: components["schemas"]["PageableObject"];
+            first?: boolean;
+            last?: boolean;
             /** Format: int32 */
             numberOfElements?: number;
+            pageable?: components["schemas"]["PageableObject"];
             empty?: boolean;
         };
         RsDataPageNoticeResBody: {


### PR DESCRIPTION
## 📌 과제 설명  
메인관리자 관련 기능을 추가하고, 관리자 회원가입·삭제·조회 API 및 프론트엔드 페이지

---

## 👩‍💻 요구 사항과 구현 내용

### ✅ 메인관리자 관련 기능
- 메인관리자 생성 메서드 추가 및 초기 데이터 (`InitData`) 설정, 관련 테스트 코드 추가
- 신규 생성된 메인관리자 (admin1, password1)

### ✅ 관리자 신규 등록
- 관리자 회원가입 API 구현, 메인 관리자로 로그인한 경우에만 접근 가능 (isSuperAdmin) 

### ✅ 관리자 삭제
- 메인관리자가 특정 관리자 계정을 삭제할 수 있는 API 구현 
- 관리자 삭제 기능 e2e 테스트 추가

### ✅ 관리자 목록 조회
- 관리자 목록 조회 API 구현  
- 관리자 목록 조회 e2e 테스트 케이스 추가

### ✅ 프론트엔드 구현
- 관리자 등록, 목록 조회 페이지 구현  
- 해당 페이지는 메인관리자만 접근 가능하도록 설정함, 일반관리자는 목록에 안뜸

---

![image](https://github.com/user-attachments/assets/5f8503f5-7fda-489a-9809-1fb97b9d3074)
![image](https://github.com/user-attachments/assets/883e51c0-6897-412c-a0b0-67e329ed9136)

Closes #54 